### PR TITLE
feat: implement initial client endpoints with mock data

### DIFF
--- a/apps/server/src/app/app.module.ts
+++ b/apps/server/src/app/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ClientAppModule } from './client-app/client-app.module';
 
 @Module({
-  imports: [],
+  imports: [ClientAppModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/server/src/app/client-app/auth/auth.controller.spec.ts
+++ b/apps/server/src/app/client-app/auth/auth.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/server/src/app/client-app/auth/auth.controller.ts
+++ b/apps/server/src/app/client-app/auth/auth.controller.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@nestjs/common';
+import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
+import { userContract } from '@mandalat-halev-project/api-interfaces';
+
+@Controller()
+export class AuthController {
+  
+  @TsRestHandler(userContract.auth.login)
+  async executeLogin() {
+    return tsRestHandler(userContract.auth.login, async ({ body }) => {
+      console.log(`Processing login for phone: ${body.phoneNumber}`);
+
+      return {
+        status: 200,
+        body: {
+          accessToken: 'mock-jwt-token-abcd-1234',
+          salesforceUserId: 101,
+        },
+      };
+    });
+  }
+}

--- a/apps/server/src/app/client-app/auth/auth.module.ts
+++ b/apps/server/src/app/client-app/auth/auth.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+
+@Module({
+  imports: [], 
+  controllers: [AuthController], 
+})
+export class AuthModule {}

--- a/apps/server/src/app/client-app/campaigns/campaigns.controller.spec.ts
+++ b/apps/server/src/app/client-app/campaigns/campaigns.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampaignsController } from './campaigns.controller';
+
+describe('CampaignsController', () => {
+  let controller: CampaignsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CampaignsController],
+    }).compile();
+
+    controller = module.get<CampaignsController>(CampaignsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/server/src/app/client-app/campaigns/campaigns.controller.ts
+++ b/apps/server/src/app/client-app/campaigns/campaigns.controller.ts
@@ -1,0 +1,160 @@
+import { Controller } from '@nestjs/common';
+import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
+import { userContract } from '@mandalat-halev-project/api-interfaces';
+
+@Controller()
+export class CampaignsController {
+  
+  // 1. Future campaigns (GET) - Multiple diverse examples
+  @TsRestHandler(userContract.campaigns.future)
+  async getFutureCampaigns() {
+    return tsRestHandler(userContract.campaigns.future, async ({ params }) => {
+      return {
+        status: 200,
+        body: [
+          {
+            id: 1,
+            name: 'Passover Food Packing',
+            description: 'Join us for our main holiday event packing food baskets for families in need.',
+            imageUrl: 'https://example.com/images/packing.jpg',
+            startDate: '2026-04-10',
+            endDate: '2026-04-10',
+            durationInHours: 4,
+            locationAddress: '1 Hatikva St',
+            locationCity: 'Tel Aviv',
+            numOfParticipants: 50,
+            numOfParticipantsRegistered: 48, 
+            isActive: true,
+            isRelevantToUser: true,
+            isUserRegistered: false,
+            userApprovalStatus: 'pending'
+          },
+          {
+            id: 3,
+            name: 'Beach Cleanup Morning',
+            description: 'Eco-friendly initiative to clean the central coastline. Equipment provided.',
+            imageUrl: 'https://example.com/images/beach.jpg',
+            startDate: '2026-05-15',
+            endDate: '2026-05-15',
+            durationInHours: 3,
+            locationAddress: 'Herbert Samuel 10',
+            locationCity: 'Tel Aviv',
+            numOfParticipants: 100,
+            numOfParticipantsRegistered: 25,
+            isActive: true,
+            isRelevantToUser: true,
+            isUserRegistered: true, // User already joined
+            userApprovalStatus: 'approved'
+          },
+          {
+            id: 4,
+            name: 'Tech Tutoring for Youth',
+            description: 'Teaching basic coding and digital skills to teenagers in community centers.',
+            imageUrl: 'https://example.com/images/tech.jpg',
+            startDate: '2026-06-01',
+            endDate: '2026-06-20',
+            durationInHours: 2,
+            locationAddress: 'Ben Gurion 45',
+            locationCity: 'Herzliya',
+            numOfParticipants: 10,
+            numOfParticipantsRegistered: 2,
+            isActive: true,
+            isRelevantToUser: true,
+            isUserRegistered: false,
+            userApprovalStatus: 'rejected' // User was rejected previously
+          }
+        ]
+      };
+    });
+  }
+
+  // 2. Past campaigns (GET) - Historical data
+  @TsRestHandler(userContract.campaigns.past)
+  async getPastCampaigns() {
+    return tsRestHandler(userContract.campaigns.past, async ({ params }) => {
+      return {
+        status: 200,
+        body: [
+          {
+            id: 101,
+            name: 'Winter Blanket Drive',
+            description: 'Collecting and distributing warm blankets for the homeless.',
+            imageUrl: 'https://example.com/images/blankets.jpg',
+            startDate: '2025-12-15',
+            endDate: '2025-12-15',
+            durationInHours: 5,
+            locationAddress: 'Rothschild 1',
+            locationCity: 'Tel Aviv',
+            numOfParticipants: 40,
+            numOfParticipantsRegistered: 40,
+            isActive: false,
+            hasUserParticipated: true // User took part in this
+          },
+          {
+            id: 102,
+            name: 'Community Garden Planting',
+            description: 'Establishing a new urban garden in the neighborhood.',
+            imageUrl: 'https://example.com/images/garden.jpg',
+            startDate: '2026-01-20',
+            endDate: '2026-01-20',
+            durationInHours: 4,
+            locationAddress: 'Weizmann 12',
+            locationCity: 'Givatayim',
+            numOfParticipants: 20,
+            numOfParticipantsRegistered: 20,
+            isActive: false,
+            hasUserParticipated: false
+          }
+        ]
+      };
+    });
+  }
+
+  // 3. Register for campaign (POST)
+  @TsRestHandler(userContract.campaigns.register)
+  async registerForCampaign() {
+    return tsRestHandler(userContract.campaigns.register, async ({ body }) => {
+      return {
+        status: 200,
+        body: {
+          campaignId: body.campaignId,
+          salesforceUserId: body.salesforceUserId,
+          requestReceivedSuccessfully: true
+        }
+      };
+    });
+  }
+
+  // 4. Unregister from campaign (POST)
+  @TsRestHandler(userContract.campaigns.unregister)
+  async unregisterFromCampaign() {
+    return tsRestHandler(userContract.campaigns.unregister, async ({ body }) => {
+      return {
+        status: 200,
+        body: {
+          campaignId: body.campaignId,
+          salesforceUserId: body.salesforceUserId,
+          requestReceivedSuccessfully: true
+        }
+      };
+    });
+  }
+
+  // 5. Check registration status (GET)
+  @TsRestHandler(userContract.campaigns.registrationStatus)
+  async getRegistrationStatus() {
+    return tsRestHandler(userContract.campaigns.registrationStatus, async ({ query }) => {
+      // Logic simulation: If campaignId is 1, return approved, otherwise pending
+      const status = query.campaignId === 1 ? 'approved' : 'pending';
+      return {
+        status: 200,
+        body: {
+          campaignId: query.campaignId,
+          salesforceUserId: query.salesforceUserId,
+          registrationStatus: status,
+          additionalInfo: status === 'approved' ? 'See you there!' : 'Awaiting admin review.'
+        }
+      };
+    });
+  }
+}

--- a/apps/server/src/app/client-app/campaigns/campaigns.module.ts
+++ b/apps/server/src/app/client-app/campaigns/campaigns.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { CampaignsController } from './campaigns.controller';
+
+@Module({
+  controllers: [CampaignsController],
+})
+export class CampaignsModule {}

--- a/apps/server/src/app/client-app/client-app.module.ts
+++ b/apps/server/src/app/client-app/client-app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
+import { UserModule } from './user/user.module';
+import { CampaignsModule } from './campaigns/campaigns.module';
+
+@Module({
+  imports: [
+    AuthModule,
+    UserModule,
+    CampaignsModule,
+  ],
+})
+export class ClientAppModule {}

--- a/apps/server/src/app/client-app/user/user.controller.spec.ts
+++ b/apps/server/src/app/client-app/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/server/src/app/client-app/user/user.controller.ts
+++ b/apps/server/src/app/client-app/user/user.controller.ts
@@ -1,0 +1,29 @@
+import { Controller } from '@nestjs/common';
+import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
+import { userContract } from '@mandalat-halev-project/api-interfaces';
+
+@Controller()
+export class UserController {
+  
+  @TsRestHandler(userContract.user.profile)
+  async getProfile() {
+    return tsRestHandler(userContract.user.profile, async ({ params }) => {
+      console.log(`Fetching profile for salesforceUserId: ${params.salesforceUserId}`);
+
+      return {
+        status: 200,
+        body: {
+          salesforceUserId: params.salesforceUserId,
+          firstName: 'Shira',
+          lastName: 'Maor',
+          email: 'shira.maor@example.com',
+          phoneNumber: '050-1234567',
+          idNumber: '123456789',
+          address: '12 Herzl St',
+          city: 'Tel Aviv',
+          birthDate: '1998-01-01',
+        },
+      };
+    });
+  }
+}

--- a/apps/server/src/app/client-app/user/user.module.ts
+++ b/apps/server/src/app/client-app/user/user.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { UserController } from './user.controller';
+
+@Module({
+  imports: [],
+  controllers: [UserController], 
+})
+export class UserModule {}

--- a/apps/server/tsconfig.app.json
+++ b/apps/server/tsconfig.app.json
@@ -20,5 +20,10 @@
     "eslint.config.js",
     "eslint.config.cjs",
     "eslint.config.mjs"
+  ],
+  "references": [
+    {
+      "path": "../../libs/shared/tsconfig.lib.json"
+    }
   ]
 }


### PR DESCRIPTION
Implemented the initial client endpoints for Auth, User, and Campaigns modules.

**Key points:**
- Created ClientAppModule and registered it in the main AppModule.
- Implemented controllers using @ts-rest/nest handlers for full type safety against the shared contract.
- Added Mock Data for all endpoints to allow the Mobile team to start integration.
- Updated tsconfig.app.json with necessary project references for the shared library.

**Verification**
I have performed local testing for all implemented endpoints (both GET and POST requests) using the browser and Thunder Client.
- Status: All requests are returning 200 OK with the expected JSON payloads.
- Examples: 
GET /api/campaigns/future/123 -> Successfully returns the future campaigns list.
POST /api/auth/login -> Successfully validates request body and returns mock access token.