### PR TITLE
Man 15 align hooks with shared zod dtos enable ts rest response

### DIFF
--- a/apps/mobile/src/api/client.spec.ts
+++ b/apps/mobile/src/api/client.spec.ts
@@ -14,6 +14,7 @@ describe('API client', () => {
   it('should expose campaign endpoints', () => {
     expect(api.campaigns).toBeDefined();
     expect(typeof api.campaigns.future).toBe('function');
+    expect(typeof api.campaigns.active).toBe('function');
     expect(typeof api.campaigns.past).toBe('function');
     expect(typeof api.campaigns.register).toBe('function');
     expect(typeof api.campaigns.unregister).toBe('function');

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -15,4 +15,5 @@ export const api = initClient(userContract, {
   baseHeaders: {
     'Content-Type': 'application/json',
   },
+  validateResponse: true,
 });

--- a/apps/mobile/src/api/hooks.integration.spec.ts
+++ b/apps/mobile/src/api/hooks.integration.spec.ts
@@ -87,12 +87,13 @@ describe('useFutureCampaigns (integration)', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const body = result.current.data?.body;
-    expect(result.current.data?.status).toBe(200);
-    expect(body).toHaveLength(3);
-    expect(body?.[0].name).toBe('Passover Food Packing');
-    expect(body?.[1].name).toBe('Beach Cleanup Morning');
-    expect(body?.[2].name).toBe('Tech Tutoring for Youth');
+    const data = result.current.data;
+    expect(data?.status).toBe(200);
+    if (data?.status !== 200) throw new Error('Expected 200');
+    expect(data.body).toHaveLength(3);
+    expect(data.body[0].name).toBe('Passover Food Packing');
+    expect(data.body[1].name).toBe('Beach Cleanup Morning');
+    expect(data.body[2].name).toBe('Tech Tutoring for Youth');
   });
 });
 
@@ -104,11 +105,12 @@ describe('usePastCampaigns (integration)', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const body = result.current.data?.body;
-    expect(result.current.data?.status).toBe(200);
-    expect(body).toHaveLength(2);
-    expect(body?.[0].name).toBe('Winter Blanket Drive');
-    expect(body?.[1].name).toBe('Community Garden Planting');
+    const data = result.current.data;
+    expect(data?.status).toBe(200);
+    if (data?.status !== 200) throw new Error('Expected 200');
+    expect(data.body).toHaveLength(2);
+    expect(data.body[0].name).toBe('Winter Blanket Drive');
+    expect(data.body[1].name).toBe('Community Garden Planting');
   });
 });
 

--- a/apps/mobile/src/api/hooks.spec.ts
+++ b/apps/mobile/src/api/hooks.spec.ts
@@ -6,6 +6,7 @@ import {
   useLogin,
   useUserProfile,
   useFutureCampaigns,
+  useActiveCampaigns,
   usePastCampaigns,
   useRegisterForCampaign,
   useUnregisterFromCampaign,
@@ -23,6 +24,7 @@ jest.mock('./client', () => ({
     },
     campaigns: {
       future: jest.fn(),
+      active: jest.fn(),
       past: jest.fn(),
       register: jest.fn(),
       unregister: jest.fn(),
@@ -152,6 +154,45 @@ describe('useFutureCampaigns', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockedApi.campaigns.future).toHaveBeenCalledWith({
+      params: { salesforceUserId: 42 },
+    });
+    expect(result.current.data).toEqual(mockCampaigns);
+  });
+});
+
+describe('useActiveCampaigns', () => {
+  it('should call api.campaigns.active with the salesforceUserId', async () => {
+    const mockCampaigns = {
+      status: 200,
+      body: [
+        {
+          id: 3,
+          name: 'Food Drive',
+          description: 'Collect food donations',
+          imageUrl: 'https://example.com/food.jpg',
+          startDate: '01/04/2026',
+          endDate: '30/04/2026',
+          durationInHours: 4,
+          locationAddress: 'Community Center',
+          locationCity: 'Jerusalem',
+          numOfParticipants: 20,
+          numOfParticipantsRegistered: 15,
+          isActive: true,
+          isRelevantToUser: true,
+          isUserRegistered: true,
+          userApprovalStatus: 'approved' as const,
+        },
+      ],
+    };
+    (mockedApi.campaigns.active as jest.Mock).mockResolvedValue(mockCampaigns);
+
+    const { result } = renderHook(() => useActiveCampaigns(42), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedApi.campaigns.active).toHaveBeenCalledWith({
       params: { salesforceUserId: 42 },
     });
     expect(result.current.data).toEqual(mockCampaigns);

--- a/apps/mobile/src/api/hooks.ts
+++ b/apps/mobile/src/api/hooks.ts
@@ -1,4 +1,9 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
+import {
+  LoginRequestDto,
+  RegisterForCampaignDto,
+  UnregisterFromCampaignDto,
+} from '@mandalat-halev-project/api-interfaces';
 import { api } from './client';
 
 // ---------------------------------------------------------------------------
@@ -11,8 +16,7 @@ import { api } from './client';
 //   login({ phoneNumber: '0501234567', idNumber: '123456789' });
 export function useLogin() {
   return useMutation({
-    mutationFn: (body: { phoneNumber: string; idNumber: string }) =>
-      api.auth.login({ body }),
+    mutationFn: (body: LoginRequestDto) => api.auth.login({ body }),
   });
 }
 
@@ -44,6 +48,14 @@ export function useFutureCampaigns(salesforceUserId: number) {
   });
 }
 
+export function useActiveCampaigns(salesforceUserId: number) {
+  return useQuery({
+    queryKey: ['campaigns', 'active', salesforceUserId],
+    queryFn: () =>
+      api.campaigns.active({ params: { salesforceUserId } }),
+  });
+}
+
 export function usePastCampaigns(salesforceUserId: number) {
   return useQuery({
     queryKey: ['campaigns', 'past', salesforceUserId],
@@ -58,23 +70,15 @@ export function usePastCampaigns(salesforceUserId: number) {
 //   register({ campaignId: 1, salesforceUserId: 42, numOfParticipantsToRegister: 1 });
 export function useRegisterForCampaign() {
   return useMutation({
-    mutationFn: (body: {
-      campaignId: number;
-      salesforceUserId: number;
-      numOfParticipantsToRegister: number;
-      additionalInfo?: string;
-    }) => api.campaigns.register({ body }),
+    mutationFn: (body: RegisterForCampaignDto) =>
+      api.campaigns.register({ body }),
   });
 }
 
 export function useUnregisterFromCampaign() {
   return useMutation({
-    mutationFn: (body: {
-      campaignId: number;
-      salesforceUserId: number;
-      numOfParticipantsToUnregister: number;
-      additionalInfo?: string;
-    }) => api.campaigns.unregister({ body }),
+    mutationFn: (body: UnregisterFromCampaignDto) =>
+      api.campaigns.unregister({ body }),
   });
 }
 

--- a/apps/mobile/src/api/hooks.ts
+++ b/apps/mobile/src/api/hooks.ts
@@ -31,8 +31,7 @@ export function useLogin() {
 export function useUserProfile(salesforceUserId: number) {
   return useQuery({
     queryKey: ['user', 'profile', salesforceUserId],
-    queryFn: () =>
-      api.user.profile({ params: { salesforceUserId } }),
+    queryFn: () => api.user.profile({ params: { salesforceUserId } }),
   });
 }
 
@@ -43,24 +42,21 @@ export function useUserProfile(salesforceUserId: number) {
 export function useFutureCampaigns(salesforceUserId: number) {
   return useQuery({
     queryKey: ['campaigns', 'future', salesforceUserId],
-    queryFn: () =>
-      api.campaigns.future({ params: { salesforceUserId } }),
+    queryFn: () => api.campaigns.future({ params: { salesforceUserId } }),
   });
 }
 
 export function useActiveCampaigns(salesforceUserId: number) {
   return useQuery({
     queryKey: ['campaigns', 'active', salesforceUserId],
-    queryFn: () =>
-      api.campaigns.active({ params: { salesforceUserId } }),
+    queryFn: () => api.campaigns.active({ params: { salesforceUserId } }),
   });
 }
 
 export function usePastCampaigns(salesforceUserId: number) {
   return useQuery({
     queryKey: ['campaigns', 'past', salesforceUserId],
-    queryFn: () =>
-      api.campaigns.past({ params: { salesforceUserId } }),
+    queryFn: () => api.campaigns.past({ params: { salesforceUserId } }),
   });
 }
 
@@ -84,7 +80,7 @@ export function useUnregisterFromCampaign() {
 
 export function useRegistrationStatus(
   campaignId: number,
-  salesforceUserId: number
+  salesforceUserId: number,
 ) {
   return useQuery({
     queryKey: ['campaigns', 'registrationStatus', campaignId, salesforceUserId],

--- a/libs/shared/src/lib/user_endpoints.ts
+++ b/libs/shared/src/lib/user_endpoints.ts
@@ -1,5 +1,5 @@
 import { initContract } from '@ts-rest/core';
-import { z } from 'zod'; 
+import { z } from 'zod';
 import {
   LoginRequestSchema,
   LoginResponseSchema,
@@ -10,7 +10,7 @@ import {
   UnregisterFromCampaignSchema,
   RegisterResponseSchema,
   GetRegistrationStatusSchema,
-  ErrorResponseSchema, 
+  ErrorResponseSchema,
 } from './user_schemas.js';
 
 const c = initContract();
@@ -43,12 +43,12 @@ export const userContract = c.router({
         401: ErrorResponseSchema, // Unauthorized (Missing/invalid token)
         403: ErrorResponseSchema, // Forbidden (No permission)
         404: ErrorResponseSchema, // User not found in Salesforce
-        500: ErrorResponseSchema, // Internal server error 
+        500: ErrorResponseSchema, // Internal server error
       },
       summary: 'Get user profile details',
     },
   },
- campaigns: {
+  campaigns: {
     future: {
       method: 'GET',
       path: '/campaigns/future/:salesforceUserId',
@@ -86,7 +86,7 @@ export const userContract = c.router({
         salesforceUserId: z.coerce.number(),
       }),
       responses: {
-        200: z.array(GetFutureCampaignSchema), 
+        200: z.array(GetFutureCampaignSchema),
         400: ErrorResponseSchema,
         401: ErrorResponseSchema,
         403: ErrorResponseSchema,

--- a/libs/shared/src/lib/user_schemas.ts
+++ b/libs/shared/src/lib/user_schemas.ts
@@ -17,30 +17,30 @@ export type ErrorResponseDto = z.infer<typeof ErrorResponseSchema>;
 
 // Request body for the Login endpoint
 export const LoginRequestSchema = z.object({
-    phoneNumber: z
-      .string()
-      .regex(/^\d+$/, { message: 'Phone number must contain digits only' })
-      .length(10, { message: 'Phone number must be 10 digits long' }),
-    idNumber: z
-      .string()
-      .regex(/^\d+$/, { message: 'ID number must contain digits only' })
-      .length(9, { message: 'ID number must be 9 digits long' }),
-  });
-  
-  // Response from the Login endpoint
-  export const LoginResponseSchema = z.object({
+  phoneNumber: z
+    .string()
+    .regex(/^\d+$/, { message: 'Phone number must contain digits only' })
+    .length(10, { message: 'Phone number must be 10 digits long' }),
+  idNumber: z
+    .string()
+    .regex(/^\d+$/, { message: 'ID number must contain digits only' })
+    .length(9, { message: 'ID number must be 9 digits long' }),
+});
+
+// Response from the Login endpoint
+export const LoginResponseSchema = z.object({
   accessToken: z.string(),
   salesforceUserId: z.number(),
 });
-  
+
 export type LoginRequestDto = z.infer<typeof LoginRequestSchema>;
 export type LoginResponseDto = z.infer<typeof LoginResponseSchema>;
-  /**
-   * USER INFO SCHEMAS
-   */
-  
-  // Schema for User Profile details
- export const UserProfileSchema = z.object({
+/**
+ * USER INFO SCHEMAS
+ */
+
+// Schema for User Profile details
+export const UserProfileSchema = z.object({
   salesforceUserId: z.number(),
   firstName: z.string(),
   lastName: z.string(),
@@ -54,15 +54,15 @@ export type LoginResponseDto = z.infer<typeof LoginResponseSchema>;
 
 export type UserProfileDto = z.infer<typeof UserProfileSchema>;
 
-    /**
-   * CAMPAIGN SCHEMAS
-   */
+/**
+ * CAMPAIGN SCHEMAS
+ */
 
 // Define allowed status values using Zod Enum
 export const ApprovalStatusSchema = z.enum(['pending', 'approved', 'rejected']);
 export type ApprovalStatus = z.infer<typeof ApprovalStatusSchema>;
 
- // Base schema for a Campaign
+// Base schema for a Campaign
 export const CampaignSchema = z.object({
   id: z.number(),
   name: z.string(),
@@ -103,7 +103,6 @@ export const RegisterForCampaignSchema = z.object({
 
 export type RegisterForCampaignDto = z.infer<typeof RegisterForCampaignSchema>;
 
-
 export const UnregisterFromCampaignSchema = z.object({
   campaignId: z.number(),
   salesforceUserId: z.number(),
@@ -111,7 +110,9 @@ export const UnregisterFromCampaignSchema = z.object({
   additionalInfo: z.string().optional(),
 });
 
-export type UnregisterFromCampaignDto = z.infer<typeof UnregisterFromCampaignSchema>;
+export type UnregisterFromCampaignDto = z.infer<
+  typeof UnregisterFromCampaignSchema
+>;
 
 export const RegisterResponseSchema = z.object({
   campaignId: z.number(),
@@ -128,4 +129,6 @@ export const GetRegistrationStatusSchema = z.object({
   additionalInfo: z.string().optional(),
 });
 
-export type GetRegistrationStatusDto = z.infer<typeof GetRegistrationStatusSchema>;
+export type GetRegistrationStatusDto = z.infer<
+  typeof GetRegistrationStatusSchema
+>;


### PR DESCRIPTION
- Enabled validateResponse: true on the ts-rest client in apps/mobile/src/api/client.ts so responses are validated at runtime against the shared Zod schemas — mismatches between server output and the contract now      
  surface immediately instead of causing silent type drift.                                                                                                                                                               
  - Replaced inline structural types in apps/mobile/src/api/hooks.ts (useLogin, useRegisterForCampaign, useUnregisterFromCampaign) with the shared DTOs (LoginRequestDto, RegisterForCampaignDto, UnregisterFromCampaignDto)
   from @mandalat-halev-project/api-interfaces, so hook inputs stay in lockstep with the contract and can't drift from it.                                                                                                  
  - Added a useActiveCampaigns hook alongside the existing future/past campaign hooks.
  - Added unit tests for useActiveCampaigns in hooks.spec.ts and an assertion for api.campaigns.active in client.spec.ts.                                                                                                   
  - Minor formatting/whitespace cleanup in libs/shared/src/lib/user_endpoints.ts and libs/shared/src/lib/user_schemas.ts.   
  