### PR TITLE
Man 13 add activity and registration modals and flows

### DIFF
--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -1,12 +1,83 @@
-import React from 'react';
-import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndicator } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndicator, TouchableOpacity, Modal } from 'react-native';
 import { ActivityItem } from '../../components/ActivityItem';
-import { useActiveCampaigns } from '../../api/hooks';
+import { useActiveCampaigns, useRegisterForCampaign } from '../../api/hooks';
 import { temporarySalesforceUserId } from '../login';
+
+interface CampaignData {
+  id: number | string;
+  name: string;
+  startDate: string;
+  durationInHours: number;
+  locationAddress: string;
+  locationCity: string;
+}
+
+interface ActiveCampaignItemProps {
+  item: CampaignData;
+  userId: number;
+  onShowModal: (msg: string) => void;
+}
+
+function ActiveCampaignItem({ item, userId, onShowModal }: ActiveCampaignItemProps) {
+  const { mutate: register, isPending } = useRegisterForCampaign();
+  const [isRegistered, setIsRegistered] = useState(false);
+
+  const handleRegister = () => {
+    register(
+      {
+        campaignId: Number(item.id),
+        salesforceUserId: userId,
+        numOfParticipantsToRegister: 1,
+      },
+      {
+        onSuccess: (res) => {
+          if (res.status === 200 && res.body.requestReceivedSuccessfully) {
+            setIsRegistered(true);
+            onShowModal('בקשת ההרשמה נשלחה בהצלחה!');
+          } else {
+            onShowModal('אירעה שגיאה בהרשמה.');
+          }
+        },
+        onError: () => {
+          onShowModal('שגיאת תקשורת. אנא נסה שוב.');
+        },
+      }
+    );
+  };
+
+  return (
+    <ActivityItem
+      title={item.name}
+      time={`${item.startDate} (${item.durationInHours} שעות)`}
+      location={`${item.locationAddress}, ${item.locationCity}`}
+      status={isRegistered ? 'נרשמת בהצלחה' : 'פתוח להרשמה'}
+    >
+      <View style={styles.actionContainer}>
+        <TouchableOpacity
+          style={[styles.registerButton, (isPending || isRegistered) && styles.disabledButton]}
+          onPress={handleRegister}
+          disabled={isPending || isRegistered}
+        >
+          <Text style={styles.registerButtonText}>
+            {isPending ? 'נרשם...' : isRegistered ? 'נרשמת' : 'הרשמה לפעילות'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </ActivityItem>
+  );
+}
 
 export default function ActivitiesScreen() {
   const userId = Number(temporarySalesforceUserId);
   const { data, isPending, isError } = useActiveCampaigns(userId);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+
+  const showModal = (msg: string) => {
+    setModalMessage(msg);
+    setModalVisible(true);
+  };
 
   if (isPending) {
     return (
@@ -16,7 +87,7 @@ export default function ActivitiesScreen() {
     );
   }
 
-  if (isError || (data && data.status !== 200)) {
+  if (isError || data?.status !== 200) {
     return (
       <SafeAreaView style={[styles.safe, styles.center]}>
         <Text style={styles.errorText}>שגיאה בטעינת הפעילויות. נסה שוב מאוחר יותר.</Text>
@@ -39,14 +110,23 @@ export default function ActivitiesScreen() {
         data={data.body}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
-          <ActivityItem
-            title={item.name}
-            time={`${item.startDate} (${item.durationInHours} שעות)`}
-            location={`${item.locationAddress}, ${item.locationCity}`}
-            status="פתוח להרשמה"
-          />
+          <ActiveCampaignItem item={item} userId={userId} onShowModal={showModal} />
         )}
+        ListEmptyComponent={
+          <Text style={styles.emptyText}>לא נמצאו פעילויות תואמות לחיפוש.</Text>
+        }
       />
+
+      <Modal visible={modalVisible} transparent={true} animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalText}>{modalMessage}</Text>
+            <TouchableOpacity onPress={() => setModalVisible(false)} style={styles.closeButton}>
+              <Text style={styles.closeButtonText}>סגור</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -58,4 +138,14 @@ const styles = StyleSheet.create({
   searchInput: { borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 5 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   errorText: { color: 'red', textAlign: 'center', marginTop: 20 },
+  emptyText: { textAlign: 'center', marginTop: 30, color: '#666', fontSize: 16 },
+  actionContainer: { alignItems: 'center', marginTop: 10 },
+  registerButton: { backgroundColor: '#FF8C00', paddingVertical: 8, paddingHorizontal: 16, borderRadius: 8 },
+  disabledButton: { backgroundColor: '#ccc' },
+  registerButtonText: { color: '#fff', fontWeight: 'bold' },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  modalContent: { backgroundColor: '#fff', padding: 20, borderRadius: 10, width: '80%', alignItems: 'center' },
+  modalText: { fontSize: 16, marginBottom: 20, textAlign: 'center' },
+  closeButton: { backgroundColor: '#FF8C00', paddingVertical: 10, paddingHorizontal: 20, borderRadius: 8 },
+  closeButtonText: { color: '#fff', fontWeight: 'bold' },
 });

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
-import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet } from 'react-native';
+import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndicator } from 'react-native';
 import { ActivityItem } from '../../components/ActivityItem';
-
-const ACTIVITIES = [
-  {
-    id: '1',
-    title: 'סדנת צילום',
-    date: '2025-05-28 10:00',
-    duration: '2 שעות',
-    location: 'מתחם מנדלת הלב',
-    status: 'פתוח להרשמה',
-  },
-  {
-    id: '2',
-    title: 'שיעור יוגה',
-    date: '2025-05-29 10:00',
-    duration: '1.5 שעות',
-    location: 'מתחם מנדלת הלב',
-    status: 'פתוח להרשמה',
-  },
-];
+import { useActiveCampaigns } from '../../api/hooks';
+import { temporarySalesforceUserId } from '../login';
 
 export default function ActivitiesScreen() {
+  const userId = Number(temporarySalesforceUserId);
+  const { data, isPending, isError } = useActiveCampaigns(userId);
+
+  if (isPending) {
+    return (
+      <SafeAreaView style={[styles.safe, styles.center]}>
+        <ActivityIndicator size="large" color="#FF8C00" />
+      </SafeAreaView>
+    );
+  }
+
+  if (isError || (data && data.status !== 200)) {
+    return (
+      <SafeAreaView style={[styles.safe, styles.center]}>
+        <Text style={styles.errorText}>שגיאה בטעינת הפעילויות. נסה שוב מאוחר יותר.</Text>
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView style={styles.safe}>
       <View style={styles.header}>
@@ -34,14 +36,14 @@ export default function ActivitiesScreen() {
       </View>
 
       <FlatList
-        data={ACTIVITIES}
-        keyExtractor={(item) => item.id}
+        data={data.body}
+        keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
           <ActivityItem
-            title={item.title}
-            time={`${item.date} (${item.duration})`}
-            location={item.location}
-            status={item.status}
+            title={item.name}
+            time={`${item.startDate} (${item.durationInHours} שעות)`}
+            location={`${item.locationAddress}, ${item.locationCity}`}
+            status="פתוח להרשמה"
           />
         )}
       />
@@ -54,4 +56,6 @@ const styles = StyleSheet.create({
   header: { padding: 15 },
   title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', marginBottom: 10 },
   searchInput: { borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 5 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  errorText: { color: 'red', textAlign: 'center', marginTop: 20 },
 });

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -3,23 +3,17 @@ import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndi
 import { ActivityItem } from '../../components/ActivityItem';
 import { useActiveCampaigns, useRegisterForCampaign } from '../../api/hooks';
 import { temporarySalesforceUserId } from '../login';
-
-interface CampaignData {
-  id: number | string;
-  name: string;
-  startDate: string;
-  durationInHours: number;
-  locationAddress: string;
-  locationCity: string;
-}
+import { CampaignDetailsModal } from '../../components/CampaignDetailsModal';
+import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 interface ActiveCampaignItemProps {
-  item: CampaignData;
+  item: GetFutureCampaignDto;
   userId: number;
   onShowModal: (msg: string) => void;
+  onPressDetails: () => void;
 }
 
-function ActiveCampaignItem({ item, userId, onShowModal }: ActiveCampaignItemProps) {
+function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
   const { mutate: register, isPending } = useRegisterForCampaign();
   const [isRegistered, setIsRegistered] = useState(false);
 
@@ -52,6 +46,7 @@ function ActiveCampaignItem({ item, userId, onShowModal }: ActiveCampaignItemPro
       time={`${item.startDate} (${item.durationInHours} שעות)`}
       location={`${item.locationAddress}, ${item.locationCity}`}
       status={isRegistered ? 'נרשמת בהצלחה' : 'פתוח להרשמה'}
+      onPressDetails={onPressDetails}
     >
       <View style={styles.actionContainer}>
         <TouchableOpacity
@@ -73,6 +68,7 @@ export default function ActivitiesScreen() {
   const { data, isPending, isError } = useActiveCampaigns(userId);
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+  const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
 
   const showModal = (msg: string) => {
     setModalMessage(msg);
@@ -110,7 +106,12 @@ export default function ActivitiesScreen() {
         data={data.body}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
-          <ActiveCampaignItem item={item} userId={userId} onShowModal={showModal} />
+          <ActiveCampaignItem 
+            item={item} 
+            userId={userId} 
+            onShowModal={showModal} 
+            onPressDetails={() => setSelectedCampaign(item)}
+          />
         )}
         ListEmptyComponent={
           <Text style={styles.emptyText}>לא נמצאו פעילויות תואמות לחיפוש.</Text>
@@ -127,6 +128,12 @@ export default function ActivitiesScreen() {
           </View>
         </View>
       </Modal>
+
+      <CampaignDetailsModal 
+        visible={!!selectedCampaign} 
+        campaign={selectedCampaign} 
+        onClose={() => setSelectedCampaign(null)} 
+      />
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndicator, TouchableOpacity, Modal } from 'react-native';
 import { ActivityItem } from '../../components/ActivityItem';
 import { useActiveCampaigns, useRegisterForCampaign } from '../../api/hooks';
+import { useQueryClient } from '@tanstack/react-query';
 import { temporarySalesforceUserId } from '../login';
 import { CampaignDetailsModal } from '../../components/CampaignDetailsModal';
 import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
@@ -14,6 +15,7 @@ interface ActiveCampaignItemProps {
 }
 
 function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
+  const queryClient = useQueryClient();
   const { mutate: register, isPending } = useRegisterForCampaign();
   const [isRegistered, setIsRegistered] = useState(false);
 
@@ -26,15 +28,22 @@ function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: Activ
       },
       {
         onSuccess: (res) => {
-          if (res.status === 200 && res.body.requestReceivedSuccessfully) {
+          // Safe check using optional chaining to avoid undefined crashes
+          if (res.status === 200 && res.body?.requestReceivedSuccessfully) {
             setIsRegistered(true);
             onShowModal('בקשת ההרשמה נשלחה בהצלחה!');
+            // Invalidate queries to sync the 'Activities' and 'My Activities' lists
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active', userId] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'future', userId] });
           } else {
-            onShowModal('אירעה שגיאה בהרשמה.');
+            // Handle API errors (e.g., 400, 500) and extract backend message if available
+            const errorMessage = (res.body as any)?.message || 'אירעה שגיאה בהרשמה. אנא נסה שוב.';
+            onShowModal(errorMessage);
           }
         },
-        onError: () => {
-          onShowModal('שגיאת תקשורת. אנא נסה שוב.');
+        onError: (error) => {
+          // Handle complete network failures safely
+          onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.');
         },
       }
     );

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FlatList, SafeAreaView, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import React, { useState } from 'react';
+import { FlatList, SafeAreaView, Text, StyleSheet, ActivityIndicator, Modal, TouchableOpacity, View } from 'react-native';
 import { temporarySalesforceUserId } from '../../login';
 import { useFutureCampaigns } from '../../../api/hooks';
 import { FutureCampaignItem } from '../../../components/FutureCampaignItem';
@@ -7,6 +7,13 @@ import { FutureCampaignItem } from '../../../components/FutureCampaignItem';
 export default function FutureActivitiesScreen() {
   const userId = Number(temporarySalesforceUserId);
   const { data, isPending, isError } = useFutureCampaigns(userId);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+
+  const showModal = (msg: string) => {
+    setModalMessage(msg);
+    setModalVisible(true);
+  };
 
   if (isPending) {
     return (
@@ -31,9 +38,22 @@ export default function FutureActivitiesScreen() {
       <FlatList
         data={data.body}
         keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => <FutureCampaignItem campaign={item} userId={userId} />}
+        renderItem={({ item }) => (
+          <FutureCampaignItem campaign={item} userId={userId} onShowModal={showModal} />
+        )}
         contentContainerStyle={{ paddingBottom: 20, paddingHorizontal: 15 }}
       />
+
+      <Modal visible={modalVisible} transparent={true} animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalText}>{modalMessage}</Text>
+            <TouchableOpacity onPress={() => setModalVisible(false)} style={styles.closeButton}>
+              <Text style={styles.closeButtonText}>סגור</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -43,4 +63,9 @@ const styles = StyleSheet.create({
   center: { justifyContent: 'center', alignItems: 'center' },
   title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', padding: 15 },
   errorText: { color: 'red', textAlign: 'center', marginBottom: 5, fontSize: 12 },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  modalContent: { backgroundColor: '#fff', padding: 20, borderRadius: 10, width: '80%', alignItems: 'center' },
+  modalText: { fontSize: 16, marginBottom: 20, textAlign: 'center' },
+  closeButton: { backgroundColor: '#FF8C00', paddingVertical: 10, paddingHorizontal: 20, borderRadius: 8 },
+  closeButtonText: { color: '#fff', fontWeight: 'bold' },
 });

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -3,12 +3,15 @@ import { FlatList, SafeAreaView, Text, StyleSheet, ActivityIndicator, Modal, Tou
 import { temporarySalesforceUserId } from '../../login';
 import { useFutureCampaigns } from '../../../api/hooks';
 import { FutureCampaignItem } from '../../../components/FutureCampaignItem';
+import { CampaignDetailsModal } from '../../../components/CampaignDetailsModal';
+import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 export default function FutureActivitiesScreen() {
   const userId = Number(temporarySalesforceUserId);
   const { data, isPending, isError } = useFutureCampaigns(userId);
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+  const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
 
   const showModal = (msg: string) => {
     setModalMessage(msg);
@@ -39,7 +42,12 @@ export default function FutureActivitiesScreen() {
         data={data.body}
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
-          <FutureCampaignItem campaign={item} userId={userId} onShowModal={showModal} />
+          <FutureCampaignItem 
+            campaign={item} 
+            userId={userId} 
+            onShowModal={showModal} 
+            onPressDetails={() => setSelectedCampaign(item)}
+          />
         )}
         contentContainerStyle={{ paddingBottom: 20, paddingHorizontal: 15 }}
       />
@@ -54,6 +62,12 @@ export default function FutureActivitiesScreen() {
           </View>
         </View>
       </Modal>
+
+      <CampaignDetailsModal 
+        visible={!!selectedCampaign} 
+        campaign={selectedCampaign} 
+        onClose={() => setSelectedCampaign(null)} 
+      />
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/app/(tabs)/my-activities/past.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/past.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, FlatList, SafeAreaView, StyleSheet, ActivityIndicator } from 'react-native';
 import { ActivityItem } from '../../../components/ActivityItem';
 import { temporarySalesforceUserId } from '../../login';
 import { usePastCampaigns } from '../../../api/hooks';
+import { CampaignDetailsModal } from '../../../components/CampaignDetailsModal';
+import type { GetPastCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 export default function PreviousActivitiesScreen() {
   const userId = Number(temporarySalesforceUserId);
   const { data, isPending, isError } = usePastCampaigns(userId);
+  const [selectedCampaign, setSelectedCampaign] = useState<GetPastCampaignDto | null>(null);
 
   if (isPending) {
     return (
@@ -39,9 +42,16 @@ export default function PreviousActivitiesScreen() {
             time={`${item.startDate} | ${item.durationInHours} שעות`}
             location={`${item.locationAddress}, ${item.locationCity}`}
             status={item.hasUserParticipated ? 'נוכח' : 'לא נוכח'}
+            onPressDetails={() => setSelectedCampaign(item)}
           />
         )}
         contentContainerStyle={{ paddingBottom: 20, paddingHorizontal: 15 }}
+      />
+
+      <CampaignDetailsModal 
+        visible={!!selectedCampaign} 
+        campaign={selectedCampaign} 
+        onClose={() => setSelectedCampaign(null)} 
       />
     </SafeAreaView>
   );

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -21,15 +21,27 @@ export const ActivityItem = ({ title, time, location, status, children }: Activi
       <TouchableOpacity style={styles.button}>
         <Text style={styles.buttonText}>לפרטים נוספים</Text>
       </TouchableOpacity>
-      <View style={styles.actions}>
-        {children}
-      </View>
+      {children && (
+        <View style={styles.actions}>
+          {children}
+        </View>
+      )}
     </View>
   </View>
 );
 
 const styles = StyleSheet.create({
-  container: { padding: 15, backgroundColor: '#f9f9f9', borderRadius: 10, marginBottom: 12, shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.1, shadowRadius: 3, elevation: 2 },
+  container: {
+    padding: 15,
+    backgroundColor: '#f9f9f9',
+    borderRadius: 10,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
+  },
   headerRow: { alignItems: 'flex-end', marginBottom: 5 },
   title: { fontSize: 18, fontWeight: 'bold', textAlign: 'right', color: '#333' },
   details: { color: '#666', textAlign: 'right', marginTop: 5, fontSize: 14 },

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -7,10 +7,11 @@ interface ActivityItemProps {
   time: string;
   location: string;
   status: string;
+  onPressDetails?: () => void;
   children?: React.ReactNode;
 }
 
-export const ActivityItem = ({ title, time, location, status, children }: ActivityItemProps) => (
+export const ActivityItem = ({ title, time, location, status, onPressDetails, children }: ActivityItemProps) => (
   <View style={styles.container}>
     <View style={styles.headerRow}>
       <Status label={status} />
@@ -18,7 +19,7 @@ export const ActivityItem = ({ title, time, location, status, children }: Activi
     <Text style={styles.title}>{title}</Text>
     <Text style={styles.details}>{time} | {location}</Text>
     <View style={styles.footerRow}>
-      <TouchableOpacity style={styles.button}>
+      <TouchableOpacity style={styles.button} onPress={onPressDetails}>
         <Text style={styles.buttonText}>לפרטים נוספים</Text>
       </TouchableOpacity>
       {children && (

--- a/apps/mobile/src/components/CampaignDetailsModal.tsx
+++ b/apps/mobile/src/components/CampaignDetailsModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, Modal, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import type { CampaignDto } from '@mandalat-halev-project/api-interfaces';
+
+interface CampaignDetailsModalProps {
+  visible: boolean;
+  campaign: CampaignDto | null;
+  onClose: () => void;
+}
+
+export function CampaignDetailsModal({ visible, campaign, onClose }: CampaignDetailsModalProps) {
+  if (!campaign) return null;
+
+  return (
+    <Modal visible={visible} transparent={true} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <ScrollView showsVerticalScrollIndicator={false}>
+            <Text style={styles.title}>{campaign.name}</Text>
+            
+            <Text style={styles.detailText}>תאריך: {campaign.startDate} {campaign.endDate && campaign.endDate !== campaign.startDate ? `- ${campaign.endDate}` : ''}</Text>
+            <Text style={styles.detailText}>משך זמן: {campaign.durationInHours} שעות</Text>
+            <Text style={styles.detailText}>מיקום: {campaign.locationAddress}, {campaign.locationCity}</Text>
+            <Text style={styles.detailText}>מקומות פנויים: {campaign.numOfParticipants ? campaign.numOfParticipants - (campaign.numOfParticipantsRegistered || 0) : 'לא מוגבל'}</Text>
+            
+            {campaign.description ? (
+              <View style={styles.descriptionContainer}>
+                <Text style={styles.descriptionTitle}>על הפעילות:</Text>
+                <Text style={styles.descriptionText}>{campaign.description}</Text>
+              </View>
+            ) : null}
+          </ScrollView>
+          <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+            <Text style={styles.closeButtonText}>סגור</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  content: { backgroundColor: '#fff', borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 25, maxHeight: '80%' },
+  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', marginBottom: 15, color: '#333' },
+  detailText: { fontSize: 16, textAlign: 'right', marginBottom: 8, color: '#555' },
+  descriptionContainer: { marginTop: 20, borderTopWidth: 1, borderTopColor: '#eee', paddingTop: 15 },
+  descriptionTitle: { fontSize: 18, fontWeight: 'bold', textAlign: 'right', marginBottom: 5, color: '#333' },
+  descriptionText: { fontSize: 16, textAlign: 'right', color: '#444', lineHeight: 24 },
+  closeButton: { backgroundColor: '#FF8C00', padding: 15, borderRadius: 10, alignItems: 'center', marginTop: 25 },
+  closeButtonText: { color: '#fff', fontSize: 16, fontWeight: 'bold' }
+});

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -7,10 +7,9 @@ import {
   useUnregisterFromCampaign 
 } from '../api/hooks';
 
-export function FutureCampaignItem({ campaign, userId }: { campaign: any, userId: number }) {
+export function FutureCampaignItem({ campaign, userId, onShowModal }: { campaign: any; userId: number; onShowModal: (msg: string) => void }) {
   const queryClient = useQueryClient();
-  const [errorMsg, setErrorMsg] = useState('');
-  const [successMsg, setSuccessMsg] = useState('');
+  const [isUnregistered, setIsUnregistered] = useState(false);
   
   // Ensure campaign.id is a number so TanStack Query keys match strictly
   const campaignId = Number(campaign.id);
@@ -26,28 +25,27 @@ export function FutureCampaignItem({ campaign, userId }: { campaign: any, userId
   }
 
   // Override the status immediately after a successful cancellation
-  if (successMsg !== '') {
+  if (isUnregistered) {
     statusText = 'בוטל';
   }
 
   const handleUnregister = () => {
-    setErrorMsg('');
-    setSuccessMsg('');
     unregister(
       { campaignId, salesforceUserId: userId, numOfParticipantsToUnregister: 1 },
       {
         onSuccess: (data) => {
           if (data.status === 200) {
-            setSuccessMsg('הרישום בוטל בהצלחה!');
+            setIsUnregistered(true);
+            onShowModal('הרישום בוטל בהצלחה!');
             // refresh campaigns list
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'future', userId] });
             // refresh status
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'registrationStatus', campaignId, userId] });
           } else {
-            setErrorMsg('משהו השתבש בביטול ההרשמה.');
+            onShowModal('משהו השתבש בביטול ההרשמה.');
           }
         },
-        onError: () => setErrorMsg('שגיאת תקשורת. אנא נסה שוב.'),
+        onError: () => onShowModal('שגיאת תקשורת. אנא נסה שוב.'),
       }
     );
   };
@@ -60,17 +58,14 @@ export function FutureCampaignItem({ campaign, userId }: { campaign: any, userId
       status={statusText}
     >
       <View style={styles.actionContainer}>
-        {errorMsg !== '' && <Text style={styles.errorText}>{errorMsg}</Text>}
-        {successMsg !== '' && <Text style={styles.successText}>{successMsg}</Text>}
-        
-        {successMsg === '' && (
+        {!isUnregistered && (
           <TouchableOpacity 
-            style={[styles.unregisterButton, isUnregistering && { opacity: 0.6 }]}
+            style={[styles.unregisterButton, isUnregistering && styles.disabledButton]}
             onPress={handleUnregister}
             disabled={isUnregistering}
           >
             <Text style={styles.unregisterButtonText}>
-              {isUnregistering ? 'מבטל רישום...' : 'ביטול רישום'}
+              {isUnregistering ? 'מבטל...' : 'ביטול רישום'}
             </Text>
           </TouchableOpacity>
         )}
@@ -87,7 +82,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     borderRadius: 8,
   },
+  disabledButton: { opacity: 0.6 },
   unregisterButtonText: { color: '#fff', fontWeight: 'bold' },
-  errorText: { color: 'red', textAlign: 'center', marginBottom: 5, fontSize: 12 },
-  successText: { color: 'green', textAlign: 'center', marginBottom: 5, fontSize: 14, fontWeight: 'bold' },
 });

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -6,8 +6,9 @@ import {
   useRegistrationStatus, 
   useUnregisterFromCampaign 
 } from '../api/hooks';
+import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
-export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetails }: { campaign: any; userId: number; onShowModal: (msg: string) => void; onPressDetails: () => void }) {
+export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetails }: { campaign: GetFutureCampaignDto; userId: number; onShowModal: (msg: string) => void; onPressDetails: () => void }) {
   const queryClient = useQueryClient();
   const [isUnregistered, setIsUnregistered] = useState(false);
   
@@ -34,18 +35,19 @@ export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetai
       { campaignId, salesforceUserId: userId, numOfParticipantsToUnregister: 1 },
       {
         onSuccess: (data) => {
-          if (data.status === 200) {
+          if (data.status === 200 && data.body?.requestReceivedSuccessfully) {
             setIsUnregistered(true);
             onShowModal('הרישום בוטל בהצלחה!');
-            // refresh campaigns list
+            // Invalidate queries to sync the 'Activities' and 'My Activities' lists
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'future', userId] });
-            // refresh status
-            queryClient.invalidateQueries({ queryKey: ['campaigns', 'registrationStatus', campaignId, userId] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active', userId] });
           } else {
-            onShowModal('משהו השתבש בביטול ההרשמה.');
+            // Handle API errors and extract backend message if available
+            const errorMessage = (data.body as any)?.message || 'משהו השתבש בביטול ההרשמה. אנא נסה שוב.';
+            onShowModal(errorMessage);
           }
         },
-        onError: () => onShowModal('שגיאת תקשורת. אנא נסה שוב.'),
+        onError: (error) => onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.'),
       }
     );
   };

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -7,7 +7,7 @@ import {
   useUnregisterFromCampaign 
 } from '../api/hooks';
 
-export function FutureCampaignItem({ campaign, userId, onShowModal }: { campaign: any; userId: number; onShowModal: (msg: string) => void }) {
+export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetails }: { campaign: any; userId: number; onShowModal: (msg: string) => void; onPressDetails: () => void }) {
   const queryClient = useQueryClient();
   const [isUnregistered, setIsUnregistered] = useState(false);
   
@@ -56,6 +56,7 @@ export function FutureCampaignItem({ campaign, userId, onShowModal }: { campaign
       time={`${campaign.startDate} | ${campaign.durationInHours} שעות`}
       location={`${campaign.locationAddress}, ${campaign.locationCity}`}
       status={statusText}
+      onPressDetails={onPressDetails}
     >
       <View style={styles.actionContainer}>
         {!isUnregistered && (


### PR DESCRIPTION
feat: implement activity registration, unregistration, and details modals

Description
This PR wires up the Activities screens to the actual API hooks, implements registration and unregistration flows with error handling, and introduces a shared "Additional Info" modal for all campaign types.

Key Changes

Activities Screen:
Replaced hardcoded mock data with the useActiveCampaigns query.
Wired up the "Register" button to call useRegisterForCampaign (campaignId, salesforceUserId, numOfParticipantsToRegister).
Added loading states to disable the button while the mutation is in-flight to prevent double submissions.
Implemented a result modal to notify the user of success or failure.

Future Activities:
Wired up the "Unregister" button to call useUnregisterFromCampaign.
Added loading state handling and a result modal for success/failure feedback.

Shared Additional Info Modal (CampaignDetailsModal):
Created a reusable sliding modal to display full CampaignDto details.
Integrated this modal across Activities, Future Activities, and Past Activities screens.

Error Handling:
Added comprehensive error handling for both mutations. The app now gracefully catches network errors, API failures, and non-200 status codes, displaying a user-friendly message in the modal instead of crashing.

Important Note Regarding State Updates:
Currently, you will not see the activities visually move between the "Activities" and "Future" tabs after a successful registration/unregistration.

This is a known limitation because our backend is currently using a stateless mock controller (CampaignsController). After a successful action, the frontend calls queryClient.invalidateQueries() to fetch the updated lists, but the mock server simply returns the exact same hardcoded initial arrays every time. Once the server is fully connected to Salesforce, the lists will sync and update automatically!