### PR TITLE
feat: added expo-secure-store to manage client session state - jwt ac…

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "expo": "*",
     "expo-linking": "*",
     "expo-router": "~6.0.23",
+    "expo-secure-store": "^55.0.13",
     "expo-splash-screen": "*",
     "expo-status-bar": "*",
     "expo-system-ui": "*",

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,19 +1,42 @@
-import { initClient } from '@ts-rest/core';
+import { initClient, tsRestFetchApi } from '@ts-rest/core';
 import { userContract } from '@mandalat-halev-project/api-interfaces';
+import { clearSession, getAccessToken } from './session';
 
 if (!process.env.EXPO_PUBLIC_API_BASE_URL) {
   throw new Error('EXPO_PUBLIC_API_BASE_URL is not set');
 }
 const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL;
 
-// initClient reads the contract and creates a typed object where every
-// endpoint becomes a callable function.  For example:
-//   api.auth.login({ body: { phoneNumber: '...', idNumber: '...' } })
-// will make a request to <BASE_URL>/auth/login with the given body.
-export const api = initClient(userContract, {
+const sharedClientOptions = {
   baseUrl: BASE_URL,
   baseHeaders: {
     'Content-Type': 'application/json',
   },
   validateResponse: true,
+};
+
+// Public client — used only for endpoints that must not carry an auth header
+// (currently auth.login). Plain default fetch implementation.
+export const apiPublic = initClient(userContract, sharedClientOptions);
+
+// Protected client — used for every endpoint the server guards with JwtAuthGuard.
+// Reads the access token from the in-memory session cache on every request and
+// attaches it as a Bearer header. On a 401, clears the session and bounces the
+// user back to /login (centralized expiry handling).
+export const api = initClient(userContract, {
+  ...sharedClientOptions,
+  api: async (args) => {
+    const token = getAccessToken();
+    const response = await tsRestFetchApi({
+      ...args,
+      headers: {
+        ...args.headers,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    if (response.status === 401) {
+      void clearSession();
+    }
+    return response;
+  },
 });

--- a/apps/mobile/src/api/hooks.integration.spec.ts
+++ b/apps/mobile/src/api/hooks.integration.spec.ts
@@ -10,6 +10,7 @@ import {
   useUnregisterFromCampaign,
   useRegistrationStatus,
 } from './hooks';
+import { setSession, clearSession } from './session';
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -28,12 +29,34 @@ function createWrapper() {
   };
 }
 
+// Protected endpoints need a valid JWT in the session. Log in once and seed the
+// session before any protected describe blocks run.
+async function loginAndSeedSession() {
+  const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+  result.current.mutate({
+    phoneNumber: '0501234567',
+    idNumber: '123456789',
+  });
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  if (result.current.data?.status !== 200) {
+    throw new Error('Login failed during integration test setup');
+  }
+  await setSession({
+    accessToken: result.current.data.body.accessToken,
+    salesforceUserId: result.current.data.body.salesforceUserId,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Auth
 // ---------------------------------------------------------------------------
 
 describe('useLogin (integration)', () => {
-  it('should login and receive a mock token from the server', async () => {
+  afterEach(async () => {
+    await clearSession();
+  });
+
+  it('should login and receive a token + salesforceUserId from the server', async () => {
     const { result } = renderHook(() => useLogin(), {
       wrapper: createWrapper(),
     });
@@ -46,10 +69,10 @@ describe('useLogin (integration)', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.status).toBe(200);
-    expect(result.current.data?.body).toEqual({
-      accessToken: 'mock-jwt-token-abcd-1234',
-      salesforceUserId: 101,
-    });
+    if (result.current.data?.status !== 200) return;
+    expect(typeof result.current.data.body.accessToken).toBe('string');
+    expect(result.current.data.body.accessToken.length).toBeGreaterThan(0);
+    expect(typeof result.current.data.body.salesforceUserId).toBe('string');
   });
 });
 
@@ -58,8 +81,15 @@ describe('useLogin (integration)', () => {
 // ---------------------------------------------------------------------------
 
 describe('useUserProfile (integration)', () => {
+  beforeAll(async () => {
+    await loginAndSeedSession();
+  });
+  afterAll(async () => {
+    await clearSession();
+  });
+
   it('should fetch the mock user profile from the server', async () => {
-    const { result } = renderHook(() => useUserProfile(42), {
+    const { result } = renderHook(() => useUserProfile(), {
       wrapper: createWrapper(),
     });
 
@@ -80,8 +110,15 @@ describe('useUserProfile (integration)', () => {
 // ---------------------------------------------------------------------------
 
 describe('useFutureCampaigns (integration)', () => {
+  beforeAll(async () => {
+    await loginAndSeedSession();
+  });
+  afterAll(async () => {
+    await clearSession();
+  });
+
   it('should fetch future campaigns from the server', async () => {
-    const { result } = renderHook(() => useFutureCampaigns(42), {
+    const { result } = renderHook(() => useFutureCampaigns(), {
       wrapper: createWrapper(),
     });
 
@@ -98,8 +135,15 @@ describe('useFutureCampaigns (integration)', () => {
 });
 
 describe('usePastCampaigns (integration)', () => {
+  beforeAll(async () => {
+    await loginAndSeedSession();
+  });
+  afterAll(async () => {
+    await clearSession();
+  });
+
   it('should fetch past campaigns from the server', async () => {
-    const { result } = renderHook(() => usePastCampaigns(42), {
+    const { result } = renderHook(() => usePastCampaigns(), {
       wrapper: createWrapper(),
     });
 
@@ -115,14 +159,20 @@ describe('usePastCampaigns (integration)', () => {
 });
 
 describe('useRegisterForCampaign (integration)', () => {
+  beforeAll(async () => {
+    await loginAndSeedSession();
+  });
+  afterAll(async () => {
+    await clearSession();
+  });
+
   it('should register for a campaign and receive confirmation', async () => {
     const { result } = renderHook(() => useRegisterForCampaign(), {
       wrapper: createWrapper(),
     });
 
     result.current.mutate({
-      campaignId: 1,
-      salesforceUserId: 42,
+      campaignId: '1',
       numOfParticipantsToRegister: 1,
     });
 
@@ -130,22 +180,27 @@ describe('useRegisterForCampaign (integration)', () => {
 
     expect(result.current.data?.status).toBe(200);
     expect(result.current.data?.body).toEqual({
-      campaignId: 1,
-      salesforceUserId: 42,
+      campaignId: '1',
       requestReceivedSuccessfully: true,
     });
   });
 });
 
 describe('useUnregisterFromCampaign (integration)', () => {
+  beforeAll(async () => {
+    await loginAndSeedSession();
+  });
+  afterAll(async () => {
+    await clearSession();
+  });
+
   it('should unregister from a campaign and receive confirmation', async () => {
     const { result } = renderHook(() => useUnregisterFromCampaign(), {
       wrapper: createWrapper(),
     });
 
     result.current.mutate({
-      campaignId: 1,
-      salesforceUserId: 42,
+      campaignId: '1',
       numOfParticipantsToUnregister: 1,
     });
 
@@ -153,28 +208,30 @@ describe('useUnregisterFromCampaign (integration)', () => {
 
     expect(result.current.data?.status).toBe(200);
     expect(result.current.data?.body).toEqual({
-      campaignId: 1,
-      salesforceUserId: 42,
+      campaignId: '1',
       requestReceivedSuccessfully: true,
     });
   });
 });
 
 describe('useRegistrationStatus (integration)', () => {
-  it('should return approved status for campaignId 1', async () => {
-    const { result } = renderHook(() => useRegistrationStatus(1, 42), {
+  beforeAll(async () => {
+    await loginAndSeedSession();
+  });
+  afterAll(async () => {
+    await clearSession();
+  });
+
+  it('should return registration status for a campaign', async () => {
+    const { result } = renderHook(() => useRegistrationStatus('1'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.status).toBe(200);
-    // Query params arrive as strings on the server, so the controller's
-    // strict equality check (campaignId === 1) is false and it returns 'pending'.
-    // This is a known server-side issue — the values come back as strings too.
     expect(result.current.data?.body).toMatchObject({
       campaignId: '1',
-      salesforceUserId: '42',
       registrationStatus: 'pending',
       additionalInfo: 'Awaiting admin review.',
     });

--- a/apps/mobile/src/api/hooks.spec.ts
+++ b/apps/mobile/src/api/hooks.spec.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { api } from './client';
+import { api, apiPublic } from './client';
 import React from 'react';
 import {
   useLogin,
@@ -13,12 +13,13 @@ import {
   useRegistrationStatus,
 } from './hooks';
 
-// Mock the api client
 jest.mock('./client', () => ({
-  api: {
+  apiPublic: {
     auth: {
       login: jest.fn(),
     },
+  },
+  api: {
     user: {
       profile: jest.fn(),
     },
@@ -34,6 +35,7 @@ jest.mock('./client', () => ({
 }));
 
 const mockedApi = api as jest.MockedObject<typeof api>;
+const mockedApiPublic = apiPublic as jest.MockedObject<typeof apiPublic>;
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -57,12 +59,12 @@ function createWrapper() {
 // ---------------------------------------------------------------------------
 
 describe('useLogin', () => {
-  it('should call api.auth.login with the provided body', async () => {
+  it('should call apiPublic.auth.login with the provided body', async () => {
     const mockResponse = {
       status: 200,
-      body: { accessToken: 'token-123', salesforceUserId: 42 },
+      body: { accessToken: 'token-123', salesforceUserId: '42' },
     };
-    (mockedApi.auth.login as jest.Mock).mockResolvedValue(mockResponse);
+    (mockedApiPublic.auth.login as jest.Mock).mockResolvedValue(mockResponse);
 
     const { result } = renderHook(() => useLogin(), {
       wrapper: createWrapper(),
@@ -75,7 +77,7 @@ describe('useLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockedApi.auth.login).toHaveBeenCalledWith({
+    expect(mockedApiPublic.auth.login).toHaveBeenCalledWith({
       body: { phoneNumber: '0501234567', idNumber: '123456789' },
     });
     expect(result.current.data).toEqual(mockResponse);
@@ -87,11 +89,11 @@ describe('useLogin', () => {
 // ---------------------------------------------------------------------------
 
 describe('useUserProfile', () => {
-  it('should call api.user.profile with the salesforceUserId', async () => {
+  it('should call api.user.profile (server identifies user from JWT)', async () => {
     const mockProfile = {
       status: 200,
       body: {
-        salesforceUserId: 42,
+        salesforceUserId: '42',
         firstName: 'Tal',
         lastName: 'Levi',
         email: 'tal@example.com',
@@ -104,15 +106,13 @@ describe('useUserProfile', () => {
     };
     (mockedApi.user.profile as jest.Mock).mockResolvedValue(mockProfile);
 
-    const { result } = renderHook(() => useUserProfile(42), {
+    const { result } = renderHook(() => useUserProfile(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockedApi.user.profile).toHaveBeenCalledWith({
-      params: { salesforceUserId: 42 },
-    });
+    expect(mockedApi.user.profile).toHaveBeenCalledWith();
     expect(result.current.data).toEqual(mockProfile);
   });
 });
@@ -122,12 +122,12 @@ describe('useUserProfile', () => {
 // ---------------------------------------------------------------------------
 
 describe('useFutureCampaigns', () => {
-  it('should call api.campaigns.future with the salesforceUserId', async () => {
+  it('should call api.campaigns.future (server identifies user from JWT)', async () => {
     const mockCampaigns = {
       status: 200,
       body: [
         {
-          id: 1,
+          id: '1',
           name: 'Beach Cleanup',
           description: 'Clean the beach',
           imageUrl: 'https://example.com/image.jpg',
@@ -147,26 +147,24 @@ describe('useFutureCampaigns', () => {
     };
     (mockedApi.campaigns.future as jest.Mock).mockResolvedValue(mockCampaigns);
 
-    const { result } = renderHook(() => useFutureCampaigns(42), {
+    const { result } = renderHook(() => useFutureCampaigns(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockedApi.campaigns.future).toHaveBeenCalledWith({
-      params: { salesforceUserId: 42 },
-    });
+    expect(mockedApi.campaigns.future).toHaveBeenCalledWith();
     expect(result.current.data).toEqual(mockCampaigns);
   });
 });
 
 describe('useActiveCampaigns', () => {
-  it('should call api.campaigns.active with the salesforceUserId', async () => {
+  it('should call api.campaigns.active (server identifies user from JWT)', async () => {
     const mockCampaigns = {
       status: 200,
       body: [
         {
-          id: 3,
+          id: '3',
           name: 'Food Drive',
           description: 'Collect food donations',
           imageUrl: 'https://example.com/food.jpg',
@@ -186,26 +184,24 @@ describe('useActiveCampaigns', () => {
     };
     (mockedApi.campaigns.active as jest.Mock).mockResolvedValue(mockCampaigns);
 
-    const { result } = renderHook(() => useActiveCampaigns(42), {
+    const { result } = renderHook(() => useActiveCampaigns(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockedApi.campaigns.active).toHaveBeenCalledWith({
-      params: { salesforceUserId: 42 },
-    });
+    expect(mockedApi.campaigns.active).toHaveBeenCalledWith();
     expect(result.current.data).toEqual(mockCampaigns);
   });
 });
 
 describe('usePastCampaigns', () => {
-  it('should call api.campaigns.past with the salesforceUserId', async () => {
+  it('should call api.campaigns.past (server identifies user from JWT)', async () => {
     const mockCampaigns = {
       status: 200,
       body: [
         {
-          id: 2,
+          id: '2',
           name: 'Park Cleanup',
           description: 'Clean the park',
           imageUrl: 'https://example.com/park.jpg',
@@ -223,15 +219,13 @@ describe('usePastCampaigns', () => {
     };
     (mockedApi.campaigns.past as jest.Mock).mockResolvedValue(mockCampaigns);
 
-    const { result } = renderHook(() => usePastCampaigns(42), {
+    const { result } = renderHook(() => usePastCampaigns(), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockedApi.campaigns.past).toHaveBeenCalledWith({
-      params: { salesforceUserId: 42 },
-    });
+    expect(mockedApi.campaigns.past).toHaveBeenCalledWith();
     expect(result.current.data).toEqual(mockCampaigns);
   });
 });
@@ -241,8 +235,7 @@ describe('useRegisterForCampaign', () => {
     const mockResponse = {
       status: 200,
       body: {
-        campaignId: 1,
-        salesforceUserId: 42,
+        campaignId: '1',
         requestReceivedSuccessfully: true,
       },
     };
@@ -253,8 +246,7 @@ describe('useRegisterForCampaign', () => {
     });
 
     result.current.mutate({
-      campaignId: 1,
-      salesforceUserId: 42,
+      campaignId: '1',
       numOfParticipantsToRegister: 1,
     });
 
@@ -262,8 +254,7 @@ describe('useRegisterForCampaign', () => {
 
     expect(mockedApi.campaigns.register).toHaveBeenCalledWith({
       body: {
-        campaignId: 1,
-        salesforceUserId: 42,
+        campaignId: '1',
         numOfParticipantsToRegister: 1,
       },
     });
@@ -276,8 +267,7 @@ describe('useUnregisterFromCampaign', () => {
     const mockResponse = {
       status: 200,
       body: {
-        campaignId: 1,
-        salesforceUserId: 42,
+        campaignId: '1',
         requestReceivedSuccessfully: true,
       },
     };
@@ -290,8 +280,7 @@ describe('useUnregisterFromCampaign', () => {
     });
 
     result.current.mutate({
-      campaignId: 1,
-      salesforceUserId: 42,
+      campaignId: '1',
       numOfParticipantsToUnregister: 1,
     });
 
@@ -299,8 +288,7 @@ describe('useUnregisterFromCampaign', () => {
 
     expect(mockedApi.campaigns.unregister).toHaveBeenCalledWith({
       body: {
-        campaignId: 1,
-        salesforceUserId: 42,
+        campaignId: '1',
         numOfParticipantsToUnregister: 1,
       },
     });
@@ -309,12 +297,11 @@ describe('useUnregisterFromCampaign', () => {
 });
 
 describe('useRegistrationStatus', () => {
-  it('should call api.campaigns.registrationStatus with campaignId and salesforceUserId', async () => {
+  it('should call api.campaigns.registrationStatus with campaignId', async () => {
     const mockResponse = {
       status: 200,
       body: {
-        campaignId: 1,
-        salesforceUserId: 42,
+        campaignId: '1',
         registrationStatus: 'approved' as const,
         additionalInfo: 'Welcome!',
       },
@@ -323,14 +310,14 @@ describe('useRegistrationStatus', () => {
       mockResponse,
     );
 
-    const { result } = renderHook(() => useRegistrationStatus(1, 42), {
+    const { result } = renderHook(() => useRegistrationStatus('1'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockedApi.campaigns.registrationStatus).toHaveBeenCalledWith({
-      query: { campaignId: 1, salesforceUserId: 42 },
+      query: { campaignId: '1' },
     });
     expect(result.current.data).toEqual(mockResponse);
   });

--- a/apps/mobile/src/api/hooks.ts
+++ b/apps/mobile/src/api/hooks.ts
@@ -4,19 +4,19 @@ import {
   RegisterForCampaignDto,
   UnregisterFromCampaignDto,
 } from '@mandalat-halev-project/api-interfaces';
-import { api } from './client';
+import { api, apiPublic } from './client';
 
 // ---------------------------------------------------------------------------
 // Auth hooks
 // ---------------------------------------------------------------------------
 
-// useMutation because login is a POST that changes state (creates a session).
+// Login uses the public client so the request goes out without a Bearer header.
 // Usage in a screen:
 //   const { mutate: login, isPending, error } = useLogin();
 //   login({ phoneNumber: '0501234567', idNumber: '123456789' });
 export function useLogin() {
   return useMutation({
-    mutationFn: (body: LoginRequestDto) => api.auth.login({ body }),
+    mutationFn: (body: LoginRequestDto) => apiPublic.auth.login({ body }),
   });
 }
 
@@ -24,14 +24,13 @@ export function useLogin() {
 // User hooks
 // ---------------------------------------------------------------------------
 
-// useQuery because this is a GET that fetches data.
-// It caches the result and refetches automatically when needed.
-// Usage:
-//   const { data, isLoading, error } = useUserProfile(salesforceUserId);
-export function useUserProfile(salesforceUserId: number) {
+// The server identifies the user from the JWT (CurrentUser('sub')), so the
+// client doesn't pass salesforceUserId. The protected `api` client attaches
+// the Bearer header automatically.
+export function useUserProfile() {
   return useQuery({
-    queryKey: ['user', 'profile', salesforceUserId],
-    queryFn: () => api.user.profile({ params: { salesforceUserId } }),
+    queryKey: ['user', 'profile'],
+    queryFn: () => api.user.profile(),
   });
 }
 
@@ -39,31 +38,27 @@ export function useUserProfile(salesforceUserId: number) {
 // Campaign hooks
 // ---------------------------------------------------------------------------
 
-export function useFutureCampaigns(salesforceUserId: number) {
+export function useFutureCampaigns() {
   return useQuery({
-    queryKey: ['campaigns', 'future', salesforceUserId],
-    queryFn: () => api.campaigns.future({ params: { salesforceUserId } }),
+    queryKey: ['campaigns', 'future'],
+    queryFn: () => api.campaigns.future(),
   });
 }
 
-export function useActiveCampaigns(salesforceUserId: number) {
+export function useActiveCampaigns() {
   return useQuery({
-    queryKey: ['campaigns', 'active', salesforceUserId],
-    queryFn: () => api.campaigns.active({ params: { salesforceUserId } }),
+    queryKey: ['campaigns', 'active'],
+    queryFn: () => api.campaigns.active(),
   });
 }
 
-export function usePastCampaigns(salesforceUserId: number) {
+export function usePastCampaigns() {
   return useQuery({
-    queryKey: ['campaigns', 'past', salesforceUserId],
-    queryFn: () => api.campaigns.past({ params: { salesforceUserId } }),
+    queryKey: ['campaigns', 'past'],
+    queryFn: () => api.campaigns.past(),
   });
 }
 
-// useMutation because registering is a POST action.
-// Usage:
-//   const { mutate: register } = useRegisterForCampaign();
-//   register({ campaignId: 1, salesforceUserId: 42, numOfParticipantsToRegister: 1 });
 export function useRegisterForCampaign() {
   return useMutation({
     mutationFn: (body: RegisterForCampaignDto) =>
@@ -78,15 +73,12 @@ export function useUnregisterFromCampaign() {
   });
 }
 
-export function useRegistrationStatus(
-  campaignId: number,
-  salesforceUserId: number,
-) {
+export function useRegistrationStatus(campaignId: string) {
   return useQuery({
-    queryKey: ['campaigns', 'registrationStatus', campaignId, salesforceUserId],
+    queryKey: ['campaigns', 'registrationStatus', campaignId],
     queryFn: () =>
       api.campaigns.registrationStatus({
-        query: { campaignId, salesforceUserId },
+        query: { campaignId },
       }),
   });
 }

--- a/apps/mobile/src/api/session.ts
+++ b/apps/mobile/src/api/session.ts
@@ -1,0 +1,118 @@
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import { router } from 'expo-router';
+import type { QueryClient } from '@tanstack/react-query';
+
+const TOKEN_KEY = 'mandalat.accessToken';
+const USER_ID_KEY = 'mandalat.salesforceUserId';
+
+// expo-secure-store only ships native modules for iOS/Android. On web (Expo
+// dev) we fall back to localStorage so the app still works — production web
+// security is out of scope until we actually target the web platform.
+const storage =
+  Platform.OS === 'web'
+    ? {
+        getItemAsync: async (key: string) =>
+          typeof window !== 'undefined'
+            ? window.localStorage.getItem(key)
+            : null,
+        setItemAsync: async (key: string, value: string) => {
+          if (typeof window !== 'undefined') {
+            window.localStorage.setItem(key, value);
+          }
+        },
+        deleteItemAsync: async (key: string) => {
+          if (typeof window !== 'undefined') {
+            window.localStorage.removeItem(key);
+          }
+        },
+      }
+    : SecureStore;
+
+type SessionSnapshot = {
+  salesforceUserId: string | null;
+  isAuthenticated: boolean;
+};
+
+let inMemoryToken: string | null = null;
+let inMemoryUserId: string | null = null;
+let snapshot: SessionSnapshot = {
+  salesforceUserId: null,
+  isAuthenticated: false,
+};
+let queryClientRef: QueryClient | null = null;
+const listeners = new Set<() => void>();
+
+function refreshSnapshot() {
+  snapshot = {
+    salesforceUserId: inMemoryUserId,
+    isAuthenticated: !!inMemoryToken,
+  };
+  for (const listener of listeners) listener();
+}
+
+export function getAccessToken(): string | null {
+  return inMemoryToken;
+}
+
+export function getSalesforceUserId(): string | null {
+  return inMemoryUserId;
+}
+
+export async function hydrateSession(): Promise<void> {
+  const [token, userId] = await Promise.all([
+    storage.getItemAsync(TOKEN_KEY),
+    storage.getItemAsync(USER_ID_KEY),
+  ]);
+  inMemoryToken = token;
+  inMemoryUserId = userId;
+  refreshSnapshot();
+}
+
+export async function setSession(args: {
+  accessToken: string;
+  salesforceUserId: string;
+}): Promise<void> {
+  await Promise.all([
+    storage.setItemAsync(TOKEN_KEY, args.accessToken),
+    storage.setItemAsync(USER_ID_KEY, args.salesforceUserId),
+  ]);
+  inMemoryToken = args.accessToken;
+  inMemoryUserId = args.salesforceUserId;
+  refreshSnapshot();
+}
+
+export async function clearSession(): Promise<void> {
+  // Guard against repeat calls (e.g. multiple in-flight 401s) so we don't loop
+  // navigation or re-clear an already-empty store.
+  if (!inMemoryToken && !inMemoryUserId) return;
+  inMemoryToken = null;
+  inMemoryUserId = null;
+  await Promise.all([
+    storage.deleteItemAsync(TOKEN_KEY).catch(() => undefined),
+    storage.deleteItemAsync(USER_ID_KEY).catch(() => undefined),
+  ]);
+  queryClientRef?.clear();
+  refreshSnapshot();
+  router.replace('/login');
+}
+
+export function registerQueryClient(client: QueryClient): void {
+  queryClientRef = client;
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function getSnapshot(): SessionSnapshot {
+  return snapshot;
+}
+
+export function useSession(): SessionSnapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -3,19 +3,17 @@ import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndi
 import { ActivityItem } from '../../components/ActivityItem';
 import { useActiveCampaigns, useRegisterForCampaign } from '../../api/hooks';
 import { useQueryClient } from '@tanstack/react-query';
-import { temporarySalesforceUserId } from '../login';
 import { CampaignDetailsModal } from '../../components/CampaignDetailsModal';
 import { QueryErrorState } from '../../components/QueryErrorState';
 import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 interface ActiveCampaignItemProps {
   item: GetFutureCampaignDto;
-  userId: number;
   onShowModal: (msg: string) => void;
   onPressDetails: () => void;
 }
 
-function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
+function ActiveCampaignItem({ item, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
   const queryClient = useQueryClient();
   const { mutate: register, isPending } = useRegisterForCampaign();
   const [isRegistered, setIsRegistered] = useState(false);
@@ -23,8 +21,7 @@ function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: Activ
   const handleRegister = () => {
     register(
       {
-        campaignId: Number(item.id),
-        salesforceUserId: userId,
+        campaignId: item.id,
         numOfParticipantsToRegister: 1,
       },
       {
@@ -34,8 +31,8 @@ function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: Activ
             setIsRegistered(true);
             onShowModal('בקשת ההרשמה נשלחה בהצלחה!');
             // Invalidate queries to sync the 'Activities' and 'My Activities' lists
-            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active', userId] });
-            queryClient.invalidateQueries({ queryKey: ['campaigns', 'future', userId] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active'] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'future'] });
           } else {
             // Handle API errors (e.g., 400, 500) and extract backend message if available
             const errorMessage = (res.body as any)?.message || 'אירעה שגיאה בהרשמה. אנא נסה שוב.';
@@ -74,8 +71,7 @@ function ActiveCampaignItem({ item, userId, onShowModal, onPressDetails }: Activ
 }
 
 export default function ActivitiesScreen() {
-  const userId = Number(temporarySalesforceUserId);
-  const { data, isPending, isError, refetch } = useActiveCampaigns(userId);
+  const { data, isPending, isError, refetch } = useActiveCampaigns();
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
   const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
@@ -112,10 +108,9 @@ export default function ActivitiesScreen() {
         data={data.body}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
-          <ActiveCampaignItem 
-            item={item} 
-            userId={userId} 
-            onShowModal={showModal} 
+          <ActiveCampaignItem
+            item={item}
+            onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />
         )}

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { FlatList, SafeAreaView, Text, StyleSheet, ActivityIndicator, Modal, TouchableOpacity, View } from 'react-native';
-import { temporarySalesforceUserId } from '../../login';
 import { useFutureCampaigns } from '../../../api/hooks';
 import { FutureCampaignItem } from '../../../components/FutureCampaignItem';
 import { CampaignDetailsModal } from '../../../components/CampaignDetailsModal';
@@ -8,8 +7,7 @@ import { QueryErrorState } from '../../../components/QueryErrorState';
 import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 export default function FutureActivitiesScreen() {
-  const userId = Number(temporarySalesforceUserId);
-  const { data, isPending, isError, refetch } = useFutureCampaigns(userId);
+  const { data, isPending, isError, refetch } = useFutureCampaigns();
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
   const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
@@ -39,10 +37,9 @@ export default function FutureActivitiesScreen() {
         data={data.body}
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
-          <FutureCampaignItem 
-            campaign={item} 
-            userId={userId} 
-            onShowModal={showModal} 
+          <FutureCampaignItem
+            campaign={item}
+            onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />
         )}

--- a/apps/mobile/src/app/(tabs)/my-activities/past.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/past.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from 'react';
 import { View, Text, FlatList, SafeAreaView, StyleSheet, ActivityIndicator } from 'react-native';
 import { ActivityItem } from '../../../components/ActivityItem';
-import { temporarySalesforceUserId } from '../../login';
 import { usePastCampaigns } from '../../../api/hooks';
 import { CampaignDetailsModal } from '../../../components/CampaignDetailsModal';
 import { QueryErrorState } from '../../../components/QueryErrorState';
 import type { GetPastCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 export default function PreviousActivitiesScreen() {
-  const userId = Number(temporarySalesforceUserId);
-  const { data, isPending, isError, refetch } = usePastCampaigns(userId);
+  const { data, isPending, isError, refetch } = usePastCampaigns();
   const [selectedCampaign, setSelectedCampaign] = useState<GetPastCampaignDto | null>(null);
 
   if (isPending) {

--- a/apps/mobile/src/app/(tabs)/personal-data.tsx
+++ b/apps/mobile/src/app/(tabs)/personal-data.tsx
@@ -10,7 +10,6 @@ import {
   StyleSheet,
 } from 'react-native';
 import { useUserProfile } from '../../api/hooks';
-import { temporarySalesforceUserId } from '../login';
 import { QueryErrorState } from '../../components/QueryErrorState';
 
 export default function PersonalDataScreen() {
@@ -19,7 +18,7 @@ export default function PersonalDataScreen() {
   const [futureActivities, setFutureActivities] = useState(true);
   const [orgMessages, setOrgMessages] = useState(true);
 
-  const { data, isPending, isError, refetch } = useUserProfile(Number(temporarySalesforceUserId));
+  const { data, isPending, isError, refetch } = useUserProfile();
   const profile = data?.status === 200 ? data.body : undefined;
 
   if (isPending) {

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
+import { registerQueryClient } from '../api/session';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -13,6 +14,11 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// Hand the QueryClient to the session module so clearSession() (triggered on
+// 401) can wipe cached responses for the previous user before navigating to
+// /login.
+registerQueryClient(queryClient);
 
 export default function RootLayout() {
   return (

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,5 +1,17 @@
+import { useEffect, useState } from 'react';
 import { Redirect } from 'expo-router';
+import { getAccessToken, hydrateSession } from '../api/session';
 
 export default function Index() {
-  return <Redirect href="/login" />;
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    hydrateSession().finally(() => setHydrated(true));
+  }, []);
+
+  if (!hydrated) return null;
+
+  return (
+    <Redirect href={getAccessToken() ? '/(tabs)/activities' : '/login'} />
+  );
 }

--- a/apps/mobile/src/app/login.tsx
+++ b/apps/mobile/src/app/login.tsx
@@ -8,7 +8,9 @@ import {
   StyleSheet,
 } from 'react-native';
 import { router } from 'expo-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { useLogin } from '../api/hooks';
+import { setSession } from '../api/session';
 import { classifyApiError } from '../api/errorClassifier';
 import {
   getLoginBanner,
@@ -16,15 +18,13 @@ import {
   LoginFieldErrors,
 } from './_loginErrors';
 
-// Temporary constant to store user ID until full auth context is implemented
-export let temporarySalesforceUserId: number | null = null;
-
 export default function LoginScreen() {
-  const [idNumber, setIdNumber] = useState('123456789');
-  const [phoneNumber, setPhoneNumber] = useState('0501234567');
+  const [idNumber, setIdNumber] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
   const [fieldErrors, setFieldErrors] = useState<LoginFieldErrors>({});
   const [banner, setBanner] = useState<string | null>(null);
   const { mutate: login, isPending } = useLogin();
+  const queryClient = useQueryClient();
 
   const handleIdChange = (text: string) => {
     setIdNumber(text);
@@ -44,28 +44,35 @@ export default function LoginScreen() {
     setBanner(null);
     setFieldErrors({});
 
-    login({ phoneNumber, idNumber }, {
-      onSuccess: (data) => {
-        if (data.status === 200) {
-          temporarySalesforceUserId = data.body.salesforceUserId;
-          router.replace('/(tabs)/activities');
-          return;
-        }
-        const apiError = classifyApiError({ data });
-        if (!apiError) return;
-        if (apiError.kind === 'validation') {
-          setFieldErrors(getLoginFieldErrors(apiError.issues));
-        } else {
+    login(
+      { phoneNumber, idNumber },
+      {
+        onSuccess: async (data) => {
+          if (data.status === 200) {
+            await setSession({
+              accessToken: data.body.accessToken,
+              salesforceUserId: data.body.salesforceUserId,
+            });
+            await queryClient.invalidateQueries();
+            router.replace('/(tabs)/activities');
+            return;
+          }
+          const apiError = classifyApiError({ data });
+          if (!apiError) return;
+          if (apiError.kind === 'validation') {
+            setFieldErrors(getLoginFieldErrors(apiError.issues));
+          } else {
+            setBanner(getLoginBanner(apiError));
+          }
+        },
+        onError: (err) => {
+          const apiError = classifyApiError({ error: err }) ?? {
+            kind: 'unknown' as const,
+          };
           setBanner(getLoginBanner(apiError));
-        }
+        },
       },
-      onError: (err) => {
-        const apiError = classifyApiError({ error: err }) ?? {
-          kind: 'unknown' as const,
-        };
-        setBanner(getLoginBanner(apiError));
-      },
-    });
+    );
   };
 
   return (
@@ -81,7 +88,6 @@ export default function LoginScreen() {
           <Text style={styles.label}>מספר תעודת זהות</Text>
           <TextInput
             style={styles.input}
-            placeholder="פורמט 9 ספרות, כולל ספרת ביקורת"
             value={idNumber}
             onChangeText={handleIdChange}
             keyboardType="numeric"

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -2,18 +2,15 @@ import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { ActivityItem } from './ActivityItem';
-import { 
-  useRegistrationStatus, 
-  useUnregisterFromCampaign 
+import {
+  useRegistrationStatus,
+  useUnregisterFromCampaign
 } from '../api/hooks';
 import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
-export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetails }: { campaign: GetFutureCampaignDto; userId: number; onShowModal: (msg: string) => void; onPressDetails: () => void }) {
+export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: { campaign: GetFutureCampaignDto; onShowModal: (msg: string) => void; onPressDetails: () => void }) {
   const queryClient = useQueryClient();
   const [isUnregistered, setIsUnregistered] = useState(false);
-  
-  // Ensure campaign.id is a number so TanStack Query keys match strictly
-  const campaignId = Number(campaign.id);
 
   // Extract isFetching to show a loading state during background refetches
   const {
@@ -21,7 +18,7 @@ export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetai
     isPending: statusPending,
     isFetching,
     isError: isStatusError,
-  } = useRegistrationStatus(campaignId, userId);
+  } = useRegistrationStatus(campaign.id);
   const { mutate: unregister, isPending: isUnregistering } = useUnregisterFromCampaign();
 
   let statusText: string;
@@ -42,15 +39,15 @@ export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetai
 
   const handleUnregister = () => {
     unregister(
-      { campaignId, salesforceUserId: userId, numOfParticipantsToUnregister: 1 },
+      { campaignId: campaign.id, numOfParticipantsToUnregister: 1 },
       {
         onSuccess: (data) => {
           if (data.status === 200 && data.body?.requestReceivedSuccessfully) {
             setIsUnregistered(true);
             onShowModal('הרישום בוטל בהצלחה!');
             // Invalidate queries to sync the 'Activities' and 'My Activities' lists
-            queryClient.invalidateQueries({ queryKey: ['campaigns', 'future', userId] });
-            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active', userId] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'future'] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active'] });
           } else {
             // Handle API errors and extract backend message if available
             const errorMessage = (data.body as any)?.message || 'משהו השתבש בביטול ההרשמה. אנא נסה שוב.';
@@ -72,7 +69,7 @@ export function FutureCampaignItem({ campaign, userId, onShowModal, onPressDetai
     >
       <View style={styles.actionContainer}>
         {!isUnregistered && (
-          <TouchableOpacity 
+          <TouchableOpacity
             style={[styles.unregisterButton, isUnregistering && styles.disabledButton]}
             onPress={handleUnregister}
             disabled={isUnregistering}

--- a/apps/mobile/src/constants/auth.ts
+++ b/apps/mobile/src/constants/auth.ts
@@ -1,3 +1,0 @@
-export const TEMP_SALESFORCE_USER_ID = "0123456789";
-export const TEST_ID_NUMBER = '000000000';
-export const TEST_PHONE_NUMBER = '0500000001';

--- a/apps/mobile/src/test-setup.ts
+++ b/apps/mobile/src/test-setup.ts
@@ -6,6 +6,27 @@ jest.mock('expo/src/winter/ImportMetaRegistry', () => ({
   },
 }));
 
+jest.mock('expo-secure-store', () => {
+  const store = new Map<string, string>();
+  return {
+    getItemAsync: jest.fn(async (key: string) => store.get(key) ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    deleteItemAsync: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+});
+
+jest.mock('expo-router', () => ({
+  router: { replace: jest.fn(), push: jest.fn(), back: jest.fn() },
+  Redirect: () => null,
+  Stack: Object.assign(() => null, { Screen: () => null }),
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+}));
+
 if (typeof global.structuredClone === 'undefined') {
   global.structuredClone = (object) => JSON.parse(JSON.stringify(object));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "expo": "*",
         "expo-linking": "*",
         "expo-router": "~6.0.23",
+        "expo-secure-store": "^55.0.13",
         "expo-splash-screen": "*",
         "expo-status-bar": "*",
         "expo-system-ui": "*",
@@ -19934,6 +19935,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.13.tgz",
+      "integrity": "sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {


### PR DESCRIPTION
Summary

  This PR connects the mobile app to the backend JWT auth flow end to end. After login, the app now persists the returned access token securely, automatically
  attaches it as a Bearer token to protected API requests, and removes the previous temporary client-side user identity handling.

  What changed

  The mobile client now uses two API clients:

  - a public client for unauthenticated endpoints like login
  - a protected client for endpoints that require JWT authentication

  A new session layer was added to manage auth state:

  - stores accessToken and salesforceUserId using expo-secure-store
  - hydrates the session on app startup
  - exposes the current auth state to the app
  - clears session data and cached queries when the backend returns 401

  The app flow was updated so that:

  - login saves the returned token and user ID before navigating into the app
  - the root route redirects users either to login or to the authenticated tabs based on the stored session
  - authenticated screens no longer pass salesforceUserId manually in requests when the backend can derive the user from the JWT

  This also removes the temporary auth workaround:

  - deleted the temporary hardcoded user/session constants
  - removed manual salesforceUserId plumbing from hooks and screen components
  - aligned query keys and invalidation logic with the new auth-based request model

  Testing updates

  Tests were updated to reflect the new auth flow:

  - mocked expo-secure-store and router behavior in test setup
  - updated hook unit tests to distinguish between public and protected API calls
  - updated integration tests to log in first, seed the session, and then exercise protected endpoints with a valid JWT