### PR TITLE
Man 20 support contacts in mobile app

### DIFF
--- a/apps/mobile/src/api/hooks.ts
+++ b/apps/mobile/src/api/hooks.ts
@@ -34,6 +34,13 @@ export function useUserProfile() {
   });
 }
 
+export function useUserContacts() {
+  return useQuery({
+    queryKey: ['user', 'contacts'],
+    queryFn: () => api.user.contacts(),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Campaign hooks
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -87,6 +87,7 @@ function ActiveCampaignItem({ item, contacts, onShowModal, onPressDetails }: Act
     <>
       <ActivityItem
         title={item.name}
+        host={`${item.host.firstName} ${item.host.lastName}`}
         time={`${item.startDate} (${item.durationInHours} שעות)`}
         location={`${item.locationAddress}, ${item.locationCity}`}
         status={isRegistered ? 'נרשמת בהצלחה' : 'פתוח להרשמה'}

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -1,79 +1,173 @@
 import React, { useState } from 'react';
 import { View, Text, FlatList, SafeAreaView, TextInput, StyleSheet, ActivityIndicator, TouchableOpacity, Modal } from 'react-native';
 import { ActivityItem } from '../../components/ActivityItem';
-import { useActiveCampaigns, useRegisterForCampaign } from '../../api/hooks';
+import { useActiveCampaigns, useRegisterForCampaign, useUserContacts } from '../../api/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { CampaignDetailsModal } from '../../components/CampaignDetailsModal';
 import { QueryErrorState } from '../../components/QueryErrorState';
-import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
+import type { GetFutureCampaignDto, ContactDto } from '@mandalat-halev-project/api-interfaces';
 
+// Props for a single campaign row in the list.
+// contacts = the full list of contacts belonging to this user (fetched once at the screen level).
 interface ActiveCampaignItemProps {
   item: GetFutureCampaignDto;
+  contacts: ContactDto[];
   onShowModal: (msg: string) => void;
   onPressDetails: () => void;
 }
 
-function ActiveCampaignItem({ item, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
+// Renders one active campaign card with a registration button.
+// Manages its own registration state and the contact-selection modal.
+function ActiveCampaignItem({ item, contacts, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
+  // useQueryClient lets us manually invalidate (refetch) cached queries after a mutation succeeds.
   const queryClient = useQueryClient();
+
+  // mutate = function to trigger the POST /campaigns/register request.
+  // isPending = true while the request is in flight.
   const { mutate: register, isPending } = useRegisterForCampaign();
+
+  // Tracks whether this specific card has already been registered in this session.
   const [isRegistered, setIsRegistered] = useState(false);
 
-  const handleRegister = () => {
+  // Controls whether the contact-selection bottom sheet is open.
+  const [selectionVisible, setSelectionVisible] = useState(false);
+
+  // The IDs of contacts currently checked in the selection modal.
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  // Sends the registration request to the server with the given contact IDs.
+  const submitRegistration = (contactIds: string[]) => {
     register(
-      {
-        campaignId: item.id,
-        contactIds: [], // TODO: Update with selected contacts in step 3
-      },
+      { campaignId: item.id, contactIds },
       {
         onSuccess: (res) => {
-          // Safe check using optional chaining to avoid undefined crashes
           if (res.status === 200 && res.body?.requestReceivedSuccessfully) {
             setIsRegistered(true);
             onShowModal('בקשת ההרשמה נשלחה בהצלחה!');
-            // Invalidate queries to sync the 'Activities' and 'My Activities' lists
+            // Refresh the active and future campaign lists so both screens show up-to-date data.
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'active'] });
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'future'] });
           } else {
-            // Handle API errors (e.g., 400, 500) and extract backend message if available
             const errorMessage = (res.body as any)?.message || 'אירעה שגיאה בהרשמה. אנא נסה שוב.';
             onShowModal(errorMessage);
           }
         },
-        onError: (error) => {
-          // Handle complete network failures safely
-          onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.');
-        },
+        onError: () => onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.'),
       }
     );
   };
 
+  // Called when the user presses the register button.
+  // If the user only has one contact (themselves), register immediately — no need to show a picker.
+  // If the user has multiple contacts, open the selection modal so they can choose who to register.
+  const handleRegister = () => {
+    if (contacts.length <= 1) {
+      submitRegistration(contacts.map((c) => c.salesforceUserId));
+    } else {
+      // Pre-select all contacts so the user can just confirm without extra taps.
+      setSelectedIds(contacts.map((c) => c.salesforceUserId));
+      setSelectionVisible(true);
+    }
+  };
+
+  // Adds or removes a contact ID from the selection when the user taps a row.
+  const toggleContact = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  // Called when the user presses "אישור" in the modal — closes the modal and submits.
+  const confirmSelection = () => {
+    setSelectionVisible(false);
+    submitRegistration(selectedIds);
+  };
+
   return (
-    <ActivityItem
-      title={item.name}
-      time={`${item.startDate} (${item.durationInHours} שעות)`}
-      location={`${item.locationAddress}, ${item.locationCity}`}
-      status={isRegistered ? 'נרשמת בהצלחה' : 'פתוח להרשמה'}
-      onPressDetails={onPressDetails}
-    >
-      <View style={styles.actionContainer}>
-        <TouchableOpacity
-          style={[styles.registerButton, (isPending || isRegistered) && styles.disabledButton]}
-          onPress={handleRegister}
-          disabled={isPending || isRegistered}
-        >
-          <Text style={styles.registerButtonText}>
-            {isPending ? 'נרשם...' : isRegistered ? 'נרשמת' : 'הרשמה לפעילות'}
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </ActivityItem>
+    <>
+      <ActivityItem
+        title={item.name}
+        time={`${item.startDate} (${item.durationInHours} שעות)`}
+        location={`${item.locationAddress}, ${item.locationCity}`}
+        status={isRegistered ? 'נרשמת בהצלחה' : 'פתוח להרשמה'}
+        onPressDetails={onPressDetails}
+      >
+        <View style={styles.actionContainer}>
+          {/* Button is greyed out and non-interactive while loading or after a successful registration. */}
+          <TouchableOpacity
+            style={[styles.registerButton, (isPending || isRegistered) && styles.disabledButton]}
+            onPress={handleRegister}
+            disabled={isPending || isRegistered}
+          >
+            <Text style={styles.registerButtonText}>
+              {isPending ? 'נרשם...' : isRegistered ? 'נרשמת' : 'הרשמה לפעילות'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </ActivityItem>
+
+      {/* Contact selection bottom sheet — only shown when the user has multiple contacts. */}
+      <Modal visible={selectionVisible} transparent animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.selectionModal}>
+            <Text style={styles.selectionTitle}>בחר משתתפים</Text>
+
+            {/* One row per contact. Tapping toggles their checkbox. */}
+            {contacts.map((contact) => {
+              const selected = selectedIds.includes(contact.salesforceUserId);
+              return (
+                <TouchableOpacity
+                  key={contact.salesforceUserId}
+                  style={styles.contactRow}
+                  onPress={() => toggleContact(contact.salesforceUserId)}
+                >
+                  {/* Visual checkbox: orange fill when selected, grey border when not. */}
+                  <View style={[styles.checkbox, selected && styles.checkboxSelected]} />
+                  <Text style={styles.contactName}>
+                    {contact.firstName} {contact.lastName}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+
+            <View style={styles.selectionButtons}>
+              <TouchableOpacity
+                onPress={() => setSelectionVisible(false)}
+                style={styles.cancelButton}
+              >
+                <Text style={styles.cancelButtonText}>ביטול</Text>
+              </TouchableOpacity>
+              {/* Confirm is disabled when no contacts are selected to prevent an empty submission. */}
+              <TouchableOpacity
+                onPress={confirmSelection}
+                disabled={selectedIds.length === 0}
+                style={[styles.confirmButton, selectedIds.length === 0 && styles.disabledButton]}
+              >
+                <Text style={styles.confirmButtonText}>אישור</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
   );
 }
 
 export default function ActivitiesScreen() {
+  // Fetch the list of active campaigns available for registration.
   const { data, isPending, isError, refetch } = useActiveCampaigns();
+
+  // Fetch the user's contacts once here and pass them down to each campaign item.
+  // Fetching here (not inside each item) means we only make one network request
+  // regardless of how many campaigns are shown.
+  const { data: contactsData } = useUserContacts();
+  const contacts = contactsData?.status === 200 ? contactsData.body : [];
+
+  // State for the post-registration notification popup.
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+
+  // Tracks which campaign the user tapped "details" on, to show the details modal.
   const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
 
   const showModal = (msg: string) => {
@@ -104,12 +198,14 @@ export default function ActivitiesScreen() {
         />
       </View>
 
+      {/* Efficiently renders only the campaign cards currently visible on screen. */}
       <FlatList
         data={data.body}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
           <ActiveCampaignItem
             item={item}
+            contacts={contacts}
             onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />
@@ -119,6 +215,7 @@ export default function ActivitiesScreen() {
         }
       />
 
+      {/* Generic notification popup shown after registration succeeds or fails. */}
       <Modal visible={modalVisible} transparent={true} animationType="fade">
         <View style={styles.modalOverlay}>
           <View style={styles.modalContent}>
@@ -130,10 +227,11 @@ export default function ActivitiesScreen() {
         </View>
       </Modal>
 
-      <CampaignDetailsModal 
-        visible={!!selectedCampaign} 
-        campaign={selectedCampaign} 
-        onClose={() => setSelectedCampaign(null)} 
+      {/* Full-screen campaign details modal, shown when the user taps "details" on a card. */}
+      <CampaignDetailsModal
+        visible={!!selectedCampaign}
+        campaign={selectedCampaign}
+        onClose={() => setSelectedCampaign(null)}
       />
     </SafeAreaView>
   );
@@ -150,9 +248,70 @@ const styles = StyleSheet.create({
   registerButton: { backgroundColor: '#FF8C00', paddingVertical: 8, paddingHorizontal: 16, borderRadius: 8 },
   disabledButton: { backgroundColor: '#ccc' },
   registerButtonText: { color: '#fff', fontWeight: 'bold' },
+  // Notification modal
   modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
   modalContent: { backgroundColor: '#fff', padding: 20, borderRadius: 10, width: '80%', alignItems: 'center' },
   modalText: { fontSize: 16, marginBottom: 20, textAlign: 'center' },
   closeButton: { backgroundColor: '#FF8C00', paddingVertical: 10, paddingHorizontal: 20, borderRadius: 8 },
   closeButtonText: { color: '#fff', fontWeight: 'bold' },
+  // Contact selection bottom sheet
+  selectionModal: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    width: '100%',
+    position: 'absolute',
+    bottom: 0,
+  },
+  selectionTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'right',
+    color: '#FF8C00',
+    marginBottom: 16,
+  },
+  contactRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 4,
+    borderWidth: 2,
+    borderColor: '#ccc',
+  },
+  checkboxSelected: {
+    backgroundColor: '#FF8C00',
+    borderColor: '#FF8C00',
+  },
+  contactName: { fontSize: 16, textAlign: 'right', flex: 1, paddingRight: 12 },
+  selectionButtons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 20,
+    gap: 12,
+  },
+  cancelButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    alignItems: 'center',
+  },
+  cancelButtonText: { color: '#666', fontWeight: 'bold' },
+  confirmButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#FF8C00',
+    alignItems: 'center',
+  },
+  confirmButtonText: { color: '#fff', fontWeight: 'bold' },
 });

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -12,13 +12,14 @@ import type { GetFutureCampaignDto, ContactDto } from '@mandalat-halev-project/a
 interface ActiveCampaignItemProps {
   item: GetFutureCampaignDto;
   contacts: ContactDto[];
+  contactsLoading: boolean;
   onShowModal: (msg: string) => void;
   onPressDetails: () => void;
 }
 
 // Renders one active campaign card with a registration button.
 // Manages its own registration state and the contact-selection modal.
-function ActiveCampaignItem({ item, contacts, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
+function ActiveCampaignItem({ item, contacts, contactsLoading, onShowModal, onPressDetails }: ActiveCampaignItemProps) {
   // useQueryClient lets us manually invalidate (refetch) cached queries after a mutation succeeds.
   const queryClient = useQueryClient();
 
@@ -96,9 +97,9 @@ function ActiveCampaignItem({ item, contacts, onShowModal, onPressDetails }: Act
         <View style={styles.actionContainer}>
           {/* Button is greyed out and non-interactive while loading or after a successful registration. */}
           <TouchableOpacity
-            style={[styles.registerButton, (isPending || isRegistered) && styles.disabledButton]}
+            style={[styles.registerButton, (isPending || isRegistered || contactsLoading) && styles.disabledButton]}
             onPress={handleRegister}
-            disabled={isPending || isRegistered}
+            disabled={isPending || isRegistered || contactsLoading}
           >
             <Text style={styles.registerButtonText}>
               {isPending ? 'נרשם...' : isRegistered ? 'נרשמת' : 'הרשמה לפעילות'}
@@ -161,7 +162,7 @@ export default function ActivitiesScreen() {
   // Fetch the user's contacts once here and pass them down to each campaign item.
   // Fetching here (not inside each item) means we only make one network request
   // regardless of how many campaigns are shown.
-  const { data: contactsData } = useUserContacts();
+  const { data: contactsData, isPending: contactsLoading } = useUserContacts();
   const contacts = contactsData?.status === 200 ? contactsData.body : [];
 
   // State for the post-registration notification popup.
@@ -207,6 +208,7 @@ export default function ActivitiesScreen() {
           <ActiveCampaignItem
             item={item}
             contacts={contacts}
+            contactsLoading={contactsLoading}
             onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -22,7 +22,7 @@ function ActiveCampaignItem({ item, onShowModal, onPressDetails }: ActiveCampaig
     register(
       {
         campaignId: item.id,
-        numOfParticipantsToRegister: 1,
+        contactIds: [], // TODO: Update with selected contacts in step 3
       },
       {
         onSuccess: (res) => {

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { FlatList, SafeAreaView, Text, StyleSheet, ActivityIndicator, Modal, TouchableOpacity, View } from 'react-native';
-import { useFutureCampaigns } from '../../../api/hooks';
+import { useFutureCampaigns, useUserContacts } from '../../../api/hooks';
 import { FutureCampaignItem } from '../../../components/FutureCampaignItem';
 import { CampaignDetailsModal } from '../../../components/CampaignDetailsModal';
 import { QueryErrorState } from '../../../components/QueryErrorState';
@@ -8,6 +8,8 @@ import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interface
 
 export default function FutureActivitiesScreen() {
   const { data, isPending, isError, refetch } = useFutureCampaigns();
+  const { data: contactsData } = useUserContacts();
+  const contacts = contactsData?.status === 200 ? contactsData.body : [];
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
   const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
@@ -39,6 +41,7 @@ export default function FutureActivitiesScreen() {
         renderItem={({ item }) => (
           <FutureCampaignItem
             campaign={item}
+            contacts={contacts}
             onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -8,7 +8,7 @@ import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interface
 
 export default function FutureActivitiesScreen() {
   const { data, isPending, isError, refetch } = useFutureCampaigns();
-  const { data: contactsData } = useUserContacts();
+  const { data: contactsData, isPending: contactsLoading } = useUserContacts();
   const contacts = contactsData?.status === 200 ? contactsData.body : [];
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
@@ -42,6 +42,7 @@ export default function FutureActivitiesScreen() {
           <FutureCampaignItem
             campaign={item}
             contacts={contacts}
+            contactsLoading={contactsLoading}
             onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />

--- a/apps/mobile/src/app/(tabs)/my-activities/past.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/past.tsx
@@ -34,6 +34,7 @@ export default function PreviousActivitiesScreen() {
         renderItem={({ item }) => (
           <ActivityItem
             title={item.name}
+            host={`${item.host.firstName} ${item.host.lastName}`}
             time={`${item.startDate} | ${item.durationInHours} שעות`}
             location={`${item.locationAddress}, ${item.locationCity}`}
             status={item.hasUserParticipated ? 'נוכח' : 'לא נוכח'}

--- a/apps/mobile/src/app/(tabs)/personal-data.tsx
+++ b/apps/mobile/src/app/(tabs)/personal-data.tsx
@@ -9,7 +9,7 @@ import {
   ActivityIndicator,
   StyleSheet,
 } from 'react-native';
-import { useUserProfile } from '../../api/hooks';
+import { useUserProfile, useUserContacts } from '../../api/hooks';
 import { QueryErrorState } from '../../components/QueryErrorState';
 
 export default function PersonalDataScreen() {
@@ -20,6 +20,9 @@ export default function PersonalDataScreen() {
 
   const { data, isPending, isError, refetch } = useUserProfile();
   const profile = data?.status === 200 ? data.body : undefined;
+
+  const { data: contactsData } = useUserContacts();
+  const contacts = contactsData?.status === 200 ? contactsData.body : [];
 
   if (isPending) {
     return (
@@ -80,14 +83,16 @@ export default function PersonalDataScreen() {
         {/* Family Members */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>בני משפחה</Text>
-          <View style={styles.card}>
-            <Text style={styles.cardName}>John Doe</Text>
-            <Text style={styles.cardDetail}>Husband</Text>
-          </View>
-          <View style={styles.card}>
-            <Text style={styles.cardName}>Alice Doe</Text>
-            <Text style={styles.cardDetail}>Daughter</Text>
-          </View>
+          {contacts.length === 0 ? (
+            <Text style={styles.cardDetail}>אין בני משפחה רשומים</Text>
+          ) : (
+            contacts.map((contact) => (
+              <View key={contact.salesforceUserId} style={styles.card}>
+                <Text style={styles.cardName}>{contact.firstName} {contact.lastName}</Text>
+                <Text style={styles.cardDetail}>ת.ז. {contact.idNumber}</Text>
+              </View>
+            ))
+          )}
         </View>
 
         {/* Notification Settings */}

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -4,6 +4,7 @@ import { Status } from './Status';
 
 interface ActivityItemProps {
   title: string;
+  host?: string;
   time: string;
   location: string;
   status: string;
@@ -11,12 +12,13 @@ interface ActivityItemProps {
   children?: React.ReactNode;
 }
 
-export const ActivityItem = ({ title, time, location, status, onPressDetails, children }: ActivityItemProps) => (
+export const ActivityItem = ({ title, host, time, location, status, onPressDetails, children }: ActivityItemProps) => (
   <View style={styles.container}>
     <View style={styles.headerRow}>
       <Status label={status} />
     </View>
     <Text style={styles.title}>{title}</Text>
+    {host && <Text style={styles.host}>{host}</Text>}
     <Text style={styles.details}>{time} | {location}</Text>
     <View style={styles.footerRow}>
       <TouchableOpacity style={styles.button} onPress={onPressDetails}>
@@ -45,6 +47,7 @@ const styles = StyleSheet.create({
   },
   headerRow: { alignItems: 'flex-end', marginBottom: 5 },
   title: { fontSize: 18, fontWeight: 'bold', textAlign: 'right', color: '#333' },
+  host: { fontSize: 13, textAlign: 'right', color: '#888', marginTop: 2 },
   details: { color: '#666', textAlign: 'right', marginTop: 5, fontSize: 14 },
   footerRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: 15 },
   button: { paddingVertical: 8 },

--- a/apps/mobile/src/components/CampaignDetailsModal.tsx
+++ b/apps/mobile/src/components/CampaignDetailsModal.tsx
@@ -17,7 +17,8 @@ export function CampaignDetailsModal({ visible, campaign, onClose }: CampaignDet
         <View style={styles.content}>
           <ScrollView showsVerticalScrollIndicator={false}>
             <Text style={styles.title}>{campaign.name}</Text>
-            
+            <Text style={styles.host}>{campaign.host.firstName} {campaign.host.lastName}</Text>
+
             <Text style={styles.detailText}>תאריך: {campaign.startDate} {campaign.endDate && campaign.endDate !== campaign.startDate ? `- ${campaign.endDate}` : ''}</Text>
             <Text style={styles.detailText}>משך זמן: {campaign.durationInHours} שעות</Text>
             <Text style={styles.detailText}>מיקום: {campaign.locationAddress}, {campaign.locationCity}</Text>
@@ -42,7 +43,8 @@ export function CampaignDetailsModal({ visible, campaign, onClose }: CampaignDet
 const styles = StyleSheet.create({
   overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   content: { backgroundColor: '#fff', borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 25, maxHeight: '80%' },
-  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', marginBottom: 15, color: '#333' },
+  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', marginBottom: 4, color: '#333' },
+  host: { fontSize: 14, textAlign: 'right', color: '#888', marginBottom: 15 },
   detailText: { fontSize: 16, textAlign: 'right', marginBottom: 8, color: '#555' },
   descriptionContainer: { marginTop: 20, borderTopWidth: 1, borderTopColor: '#eee', paddingTop: 15 },
   descriptionTitle: { fontSize: 18, fontWeight: 'bold', textAlign: 'right', marginBottom: 5, color: '#333' },

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -1,18 +1,24 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Modal } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { ActivityItem } from './ActivityItem';
 import {
   useRegistrationStatus,
   useUnregisterFromCampaign
 } from '../api/hooks';
-import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
+import type { GetFutureCampaignDto, ContactDto } from '@mandalat-halev-project/api-interfaces';
 
-export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: { campaign: GetFutureCampaignDto; onShowModal: (msg: string) => void; onPressDetails: () => void }) {
+export function FutureCampaignItem({ campaign, contacts, onShowModal, onPressDetails }: {
+  campaign: GetFutureCampaignDto;
+  contacts: ContactDto[];
+  onShowModal: (msg: string) => void;
+  onPressDetails: () => void;
+}) {
   const queryClient = useQueryClient();
   const [isUnregistered, setIsUnregistered] = useState(false);
+  const [selectionVisible, setSelectionVisible] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
-  // Extract isFetching to show a loading state during background refetches
   const {
     data: statusData,
     isPending: statusPending,
@@ -32,56 +38,121 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: { 
     statusText = 'לא ידוע';
   }
 
-  // Override the status immediately after a successful cancellation
   if (isUnregistered) {
     statusText = 'בוטל';
   }
 
-  const handleUnregister = () => {
+  // Sends the unregistration request with the given contact IDs.
+  const performUnregister = (contactIds: string[]) => {
     unregister(
-      { campaignId: campaign.id, contactIds: [] },
+      { campaignId: campaign.id, contactIds },
       {
         onSuccess: (data) => {
           if (data.status === 200 && data.body?.requestReceivedSuccessfully) {
             setIsUnregistered(true);
             onShowModal('הרישום בוטל בהצלחה!');
-            // Invalidate queries to sync the 'Activities' and 'My Activities' lists
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'future'] });
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'active'] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'registrationStatus', campaign.id] });
           } else {
-            // Handle API errors and extract backend message if available
             const errorMessage = (data.body as any)?.message || 'משהו השתבש בביטול ההרשמה. אנא נסה שוב.';
             onShowModal(errorMessage);
           }
         },
-        onError: (error) => onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.'),
+        onError: () => onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.'),
       }
     );
   };
 
+  // If the user has only one contact (themselves), unregister immediately.
+  // If they have multiple contacts, open the selection modal.
+  const handleUnregister = () => {
+    if (contacts.length <= 1) {
+      performUnregister(contacts.map((c) => c.salesforceUserId));
+    } else {
+      setSelectedIds(contacts.map((c) => c.salesforceUserId));
+      setSelectionVisible(true);
+    }
+  };
+
+  const toggleContact = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const confirmUnregister = () => {
+    setSelectionVisible(false);
+    performUnregister(selectedIds);
+  };
+
   return (
-    <ActivityItem
-      title={campaign.name}
-      host={`${campaign.host.firstName} ${campaign.host.lastName}`}
-      time={`${campaign.startDate} | ${campaign.durationInHours} שעות`}
-      location={`${campaign.locationAddress}, ${campaign.locationCity}`}
-      status={statusText}
-      onPressDetails={onPressDetails}
-    >
-      <View style={styles.actionContainer}>
-        {!isUnregistered && (
-          <TouchableOpacity
-            style={[styles.unregisterButton, isUnregistering && styles.disabledButton]}
-            onPress={handleUnregister}
-            disabled={isUnregistering}
-          >
-            <Text style={styles.unregisterButtonText}>
-              {isUnregistering ? 'מבטל...' : 'ביטול רישום'}
-            </Text>
-          </TouchableOpacity>
-        )}
-      </View>
-    </ActivityItem>
+    <>
+      <ActivityItem
+        title={campaign.name}
+        host={`${campaign.host.firstName} ${campaign.host.lastName}`}
+        time={`${campaign.startDate} | ${campaign.durationInHours} שעות`}
+        location={`${campaign.locationAddress}, ${campaign.locationCity}`}
+        status={statusText}
+        onPressDetails={onPressDetails}
+      >
+        <View style={styles.actionContainer}>
+          {!isUnregistered && (
+            <TouchableOpacity
+              style={[styles.unregisterButton, isUnregistering && styles.disabledButton]}
+              onPress={handleUnregister}
+              disabled={isUnregistering}
+            >
+              <Text style={styles.unregisterButtonText}>
+                {isUnregistering ? 'מבטל...' : 'ביטול רישום'}
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </ActivityItem>
+
+      {/* Contact selection bottom sheet — only shown when the user has multiple contacts. */}
+      <Modal visible={selectionVisible} transparent animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.selectionModal}>
+            <Text style={styles.selectionTitle}>בחר משתתפים לביטול</Text>
+
+            {contacts.map((contact) => {
+              const selected = selectedIds.includes(contact.salesforceUserId);
+              return (
+                <TouchableOpacity
+                  key={contact.salesforceUserId}
+                  style={styles.contactRow}
+                  onPress={() => toggleContact(contact.salesforceUserId)}
+                >
+                  <View style={[styles.checkbox, selected && styles.checkboxSelected]} />
+                  <Text style={styles.contactName}>
+                    {contact.firstName} {contact.lastName}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+
+            <View style={styles.selectionButtons}>
+              <TouchableOpacity
+                onPress={() => setSelectionVisible(false)}
+                style={styles.cancelButton}
+              >
+                <Text style={styles.cancelButtonText}>ביטול</Text>
+              </TouchableOpacity>
+              {/* Confirm is disabled when no contacts are selected. */}
+              <TouchableOpacity
+                onPress={confirmUnregister}
+                disabled={selectedIds.length === 0}
+                style={[styles.confirmButton, selectedIds.length === 0 && styles.disabledButton]}
+              >
+                <Text style={styles.confirmButtonText}>אישור</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
   );
 }
 
@@ -95,4 +166,63 @@ const styles = StyleSheet.create({
   },
   disabledButton: { opacity: 0.6 },
   unregisterButtonText: { color: '#fff', fontWeight: 'bold' },
+  // Contact selection bottom sheet
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  selectionModal: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    width: '100%',
+  },
+  selectionTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'right',
+    color: '#ff4444',
+    marginBottom: 16,
+  },
+  contactRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 4,
+    borderWidth: 2,
+    borderColor: '#ccc',
+  },
+  checkboxSelected: {
+    backgroundColor: '#ff4444',
+    borderColor: '#ff4444',
+  },
+  contactName: { fontSize: 16, textAlign: 'right', flex: 1, paddingRight: 12 },
+  selectionButtons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 20,
+    gap: 12,
+  },
+  cancelButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    alignItems: 'center',
+  },
+  cancelButtonText: { color: '#666', fontWeight: 'bold' },
+  confirmButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#ff4444',
+    alignItems: 'center',
+  },
+  confirmButtonText: { color: '#fff', fontWeight: 'bold' },
 });

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -39,7 +39,7 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: { 
 
   const handleUnregister = () => {
     unregister(
-      { campaignId: campaign.id, numOfParticipantsToUnregister: 1 },
+      { campaignId: campaign.id, contactIds: [] },
       {
         onSuccess: (data) => {
           if (data.status === 200 && data.body?.requestReceivedSuccessfully) {

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -26,7 +26,7 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: { 
     statusText = 'טוען...';
   } else if (statusData?.status === 200) {
     statusText = statusData.body.registrationStatus === 'approved' ? 'רשום' : 'מחכה לאישור';
-  } else if (isStatusError || (statusData && statusData.status !== 200)) {
+  } else if (isStatusError || statusData) {
     statusText = 'שגיאה בטעינת הסטטוס';
   } else {
     statusText = 'לא ידוע';

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -62,6 +62,7 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: { 
   return (
     <ActivityItem
       title={campaign.name}
+      host={`${campaign.host.firstName} ${campaign.host.lastName}`}
       time={`${campaign.startDate} | ${campaign.durationInHours} שעות`}
       location={`${campaign.locationAddress}, ${campaign.locationCity}`}
       status={statusText}

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -8,9 +8,10 @@ import {
 } from '../api/hooks';
 import type { GetFutureCampaignDto, ContactDto } from '@mandalat-halev-project/api-interfaces';
 
-export function FutureCampaignItem({ campaign, contacts, onShowModal, onPressDetails }: {
+export function FutureCampaignItem({ campaign, contacts, contactsLoading, onShowModal, onPressDetails }: {
   campaign: GetFutureCampaignDto;
   contacts: ContactDto[];
+  contactsLoading: boolean;
   onShowModal: (msg: string) => void;
   onPressDetails: () => void;
 }) {
@@ -99,9 +100,9 @@ export function FutureCampaignItem({ campaign, contacts, onShowModal, onPressDet
         <View style={styles.actionContainer}>
           {!isUnregistered && (
             <TouchableOpacity
-              style={[styles.unregisterButton, isUnregistering && styles.disabledButton]}
+              style={[styles.unregisterButton, (isUnregistering || contactsLoading) && styles.disabledButton]}
               onPress={handleUnregister}
-              disabled={isUnregistering}
+              disabled={isUnregistering || contactsLoading}
             >
               <Text style={styles.unregisterButtonText}>
                 {isUnregistering ? 'מבטל...' : 'ביטול רישום'}


### PR DESCRIPTION
feat: support contacts in mobile app

Summary
Update register/unregister call sites — useRegisterForCampaign and useUnregisterFromCampaign now send contactIds: string[] instead of the old participant count field. Updated all component call sites accordingly.

Add useUserContacts hook — new hook for GET /user/contacts/. Displayed the contacts list in the personal data screen under "בני משפחה", replacing the hardcoded placeholder data.

Registration flow UI — the register button in the activities screen now opens a contact-selection bottom sheet when the user has more than one contact. Single-contact users are registered immediately with no modal. Contacts are fetched once at the screen level and passed down to avoid redundant requests.

Unregistration flow UI — mirrors the registration flow: single-contact users are unregistered immediately; multi-contact users get a contact-selection modal. After a successful unregistration, the registrationStatus cache for that campaign is invalidated so the status badge refreshes.

Display host on campaign screens — added an optional host prop to ActivityItem and updated all campaign screens (active, future, past) and CampaignDetailsModal to display the host's full name beneath the campaign name.

Loading guard — both the register and unregister buttons are disabled while the contacts list is still loading, preventing an accidental submission with an empty contactIds array.

Files changed
hooks.ts — added useUserContacts
activities.tsx — registration flow with contact selection modal
FutureCampaignItem.tsx — unregistration flow with contact selection modal
future.tsx — passes contacts + loading state to FutureCampaignItem
personal-data.tsx — displays real contacts list
ActivityItem.tsx — added optional host prop
CampaignDetailsModal.tsx — displays host name
past.tsx — passes host to ActivityItem