### PR TITLE
feat: Firebase SMS phone authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,7 @@ CLAUDE.md
 
 
 .nx/polygraph
-.claude/worktrees
-.claude/settings.local.json
+.claude/
 .agents/
 .cursor/
 AGENTS.md

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,6 +1,6 @@
 import { initClient, tsRestFetchApi } from '@ts-rest/core';
 import { userContract } from '@mandalat-halev-project/api-interfaces';
-import { clearSession, getAccessToken } from './session';
+import { clearSession, getValidToken } from './session';
 
 if (!process.env.EXPO_PUBLIC_API_BASE_URL) {
   throw new Error('EXPO_PUBLIC_API_BASE_URL is not set');
@@ -19,24 +19,37 @@ const sharedClientOptions = {
 // (currently auth.login). Plain default fetch implementation.
 export const apiPublic = initClient(userContract, sharedClientOptions);
 
-// Protected client — used for every endpoint the server guards with JwtAuthGuard.
-// Reads the access token from the in-memory session cache on every request and
-// attaches it as a Bearer header. On a 401, clears the session and bounces the
-// user back to /login (centralized expiry handling).
+const withAuth = (headers: Record<string, string>, token: string | null) => ({
+  ...headers,
+  ...(token ? { Authorization: `Bearer ${token}` } : {}),
+});
+
+// Protected client — used for every endpoint the server guards. Each request
+// carries a current Firebase ID token (getValidToken). A 401 usually means the
+// token expired, so we force-refresh it once and retry; if it still fails we
+// clear the session and bounce the user back to /login.
 export const api = initClient(userContract, {
   ...sharedClientOptions,
   api: async (args) => {
-    const token = getAccessToken();
-    const response = await tsRestFetchApi({
+    const token = await getValidToken();
+    let response = await tsRestFetchApi({
       ...args,
-      headers: {
-        ...args.headers,
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
+      headers: withAuth(args.headers, token),
     });
+
     if (response.status === 401) {
-      void clearSession();
+      const refreshed = await getValidToken(true);
+      if (refreshed && refreshed !== token) {
+        response = await tsRestFetchApi({
+          ...args,
+          headers: withAuth(args.headers, refreshed),
+        });
+      }
+      if (response.status === 401) {
+        void clearSession();
+      }
     }
+
     return response;
   },
 });

--- a/apps/mobile/src/api/hooks.ts
+++ b/apps/mobile/src/api/hooks.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
   LoginRequestDto,
+  CreateSessionDto,
   RegisterForCampaignDto,
   UnregisterFromCampaignDto,
 } from '@mandalat-halev-project/api-interfaces';
@@ -17,6 +18,20 @@ import { api, apiPublic } from './client';
 export function useLogin() {
   return useMutation({
     mutationFn: (body: LoginRequestDto) => apiPublic.auth.login({ body }),
+  });
+}
+
+// Finalizes the Firebase login: POSTs the Firebase ID token (as a Bearer
+// header) plus the phone/id body to /auth/session. Uses the public client so
+// it is not coupled to the protected client's 401-expiry handling. The server
+// sets a Salesforce custom claim and returns { ok: true }.
+export function useCreateSession() {
+  return useMutation({
+    mutationFn: ({ body, idToken }: CreateSessionDto) =>
+      apiPublic.auth.session({
+        body,
+        extraHeaders: { Authorization: `Bearer ${idToken}` },
+      }),
   });
 }
 

--- a/apps/mobile/src/api/session.ts
+++ b/apps/mobile/src/api/session.ts
@@ -1,100 +1,48 @@
-import { useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import { router } from 'expo-router';
 import type { QueryClient } from '@tanstack/react-query';
+import { auth } from '../firebase/config';
 
-const TOKEN_KEY = 'mandalat.accessToken';
-const USER_ID_KEY = 'mandalat.salesforceUserId';
+const TOKEN_KEY = 'mandalat.idToken';
 
-// expo-secure-store only ships native modules for iOS/Android. On web (Expo
-// dev) we fall back to localStorage so the app still works — production web
-// security is out of scope until we actually target the web platform.
-const storage =
-  Platform.OS === 'web'
-    ? {
-        getItemAsync: async (key: string) =>
-          typeof window !== 'undefined'
-            ? window.localStorage.getItem(key)
-            : null,
-        setItemAsync: async (key: string, value: string) => {
-          if (typeof window !== 'undefined') {
-            window.localStorage.setItem(key, value);
-          }
-        },
-        deleteItemAsync: async (key: string) => {
-          if (typeof window !== 'undefined') {
-            window.localStorage.removeItem(key);
-          }
-        },
-      }
-    : SecureStore;
-
-type SessionSnapshot = {
-  salesforceUserId: string | null;
-  isAuthenticated: boolean;
-};
+// expo-secure-store ships native modules only. Persist on iOS/Android; on web
+// (dev) the calls are skipped so the app still runs without a storage shim.
+const canPersist = Platform.OS !== 'web';
 
 let inMemoryToken: string | null = null;
-let inMemoryUserId: string | null = null;
-let snapshot: SessionSnapshot = {
-  salesforceUserId: null,
-  isAuthenticated: false,
-};
 let queryClientRef: QueryClient | null = null;
-const listeners = new Set<() => void>();
 
-function refreshSnapshot() {
-  snapshot = {
-    salesforceUserId: inMemoryUserId,
-    isAuthenticated: !!inMemoryToken,
-  };
-  for (const listener of listeners) listener();
-}
-
-export function getAccessToken(): string | null {
+// The token persisted from the last session — used at startup to decide whether
+// to route into the app. Within a running session the live token comes from
+// getValidToken().
+export function getStoredToken(): string | null {
   return inMemoryToken;
 }
 
-export function getSalesforceUserId(): string | null {
-  return inMemoryUserId;
-}
-
+// Loads any persisted Firebase ID token on app startup.
 export async function hydrateSession(): Promise<void> {
-  const [token, userId] = await Promise.all([
-    storage.getItemAsync(TOKEN_KEY),
-    storage.getItemAsync(USER_ID_KEY),
-  ]);
-  inMemoryToken = token;
-  inMemoryUserId = userId;
-  refreshSnapshot();
+  if (canPersist) {
+    inMemoryToken = await SecureStore.getItemAsync(TOKEN_KEY);
+  }
 }
 
-export async function setSession(args: {
-  accessToken: string;
-  salesforceUserId: string;
-}): Promise<void> {
-  await Promise.all([
-    storage.setItemAsync(TOKEN_KEY, args.accessToken),
-    storage.setItemAsync(USER_ID_KEY, args.salesforceUserId),
-  ]);
-  inMemoryToken = args.accessToken;
-  inMemoryUserId = args.salesforceUserId;
-  refreshSnapshot();
+// Stores the Firebase ID token as the app session.
+export async function setSession(idToken: string): Promise<void> {
+  inMemoryToken = idToken;
+  if (canPersist) {
+    await SecureStore.setItemAsync(TOKEN_KEY, idToken);
+  }
 }
 
 export async function clearSession(): Promise<void> {
-  // Guard against repeat calls (e.g. multiple in-flight 401s) so we don't loop
-  // navigation or re-clear an already-empty store.
-  if (!inMemoryToken && !inMemoryUserId) return;
+  // Guard against repeat calls (e.g. several in-flight 401s at once).
+  if (!inMemoryToken) return;
   inMemoryToken = null;
-  inMemoryUserId = null;
-  await Promise.all([
-    storage.deleteItemAsync(TOKEN_KEY).catch(() => undefined),
-    storage.deleteItemAsync(USER_ID_KEY).catch(() => undefined),
-  ]);
+  if (canPersist) {
+    await SecureStore.deleteItemAsync(TOKEN_KEY).catch(() => undefined);
+  }
   queryClientRef?.clear();
-  refreshSnapshot();
   router.replace('/login');
 }
 
@@ -102,17 +50,21 @@ export function registerQueryClient(client: QueryClient): void {
   queryClientRef = client;
 }
 
-function subscribe(callback: () => void): () => void {
-  listeners.add(callback);
-  return () => {
-    listeners.delete(callback);
-  };
-}
-
-function getSnapshot(): SessionSnapshot {
-  return snapshot;
-}
-
-export function useSession(): SessionSnapshot {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+// Returns a current Firebase ID token for protected API calls. Firebase
+// refreshes the token automatically, so getIdToken() yields a valid one (pass
+// forceRefresh on a 401); the result is mirrored into secure storage. Falls
+// back to the last stored token when the Firebase user isn't in memory (e.g.
+// just after a cold start, before re-authentication).
+export async function getValidToken(
+  forceRefresh = false,
+): Promise<string | null> {
+  const user = auth.currentUser;
+  if (!user) {
+    return inMemoryToken;
+  }
+  const token = await user.getIdToken(forceRefresh);
+  if (token !== inMemoryToken) {
+    await setSession(token);
+  }
+  return token;
 }

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,21 +1,40 @@
 import React from 'react';
 import { Tabs } from 'expo-router';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { clearSession } from '../../api/session';
+
+// clearSession() wipes the stored Firebase ID token + query cache and routes
+// back to /login.
+function LogoutButton() {
+  return (
+    <TouchableOpacity
+      onPress={() => {
+        void clearSession();
+      }}
+      style={styles.logout}
+    >
+      <Text style={styles.logoutText}>התנתק</Text>
+    </TouchableOpacity>
+  );
+}
 
 export default function TabsLayout() {
   return (
-    <Tabs initialRouteName="activities">
+    <Tabs
+      initialRouteName="activities"
+      screenOptions={{ headerRight: () => <LogoutButton /> }}
+    >
       <Tabs.Screen
         name="my-activities"
         options={{ title: 'הפעילויות שלי', headerShown: false }}
       />
-      <Tabs.Screen
-        name="personal-data"
-        options={{ title: 'נתונים אישיים' }}
-      />
-      <Tabs.Screen
-        name="activities"
-        options={{ title: 'פעילויות' }}
-      />
+      <Tabs.Screen name="personal-data" options={{ title: 'נתונים אישיים' }} />
+      <Tabs.Screen name="activities" options={{ title: 'פעילויות' }} />
     </Tabs>
   );
 }
+
+const styles = StyleSheet.create({
+  logout: { marginHorizontal: 16 },
+  logoutText: { color: '#FF8C00', fontWeight: 'bold', fontSize: 16 },
+});

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout() {
       <Stack>
         <Stack.Screen name="index" options={{ headerShown: false }} />
         <Stack.Screen name="login" options={{ headerShown: false }} />
+        <Stack.Screen name="verify-sms" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       </Stack>
     </QueryClientProvider>

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Redirect } from 'expo-router';
-import { getAccessToken, hydrateSession } from '../api/session';
+import { getStoredToken, hydrateSession } from '../api/session';
 
 export default function Index() {
   const [hydrated, setHydrated] = useState(false);
@@ -12,6 +12,6 @@ export default function Index() {
   if (!hydrated) return null;
 
   return (
-    <Redirect href={getAccessToken() ? '/(tabs)/activities' : '/login'} />
+    <Redirect href={getStoredToken() ? '/(tabs)/activities' : '/login'} />
   );
 }

--- a/apps/mobile/src/app/login.tsx
+++ b/apps/mobile/src/app/login.tsx
@@ -8,9 +8,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import { router } from 'expo-router';
-import { useQueryClient } from '@tanstack/react-query';
 import { useLogin } from '../api/hooks';
-import { setSession } from '../api/session';
 import { classifyApiError } from '../api/errorClassifier';
 import {
   getLoginBanner,
@@ -24,7 +22,6 @@ export default function LoginScreen() {
   const [fieldErrors, setFieldErrors] = useState<LoginFieldErrors>({});
   const [banner, setBanner] = useState<string | null>(null);
   const { mutate: login, isPending } = useLogin();
-  const queryClient = useQueryClient();
 
   const handleIdChange = (text: string) => {
     setIdNumber(text);
@@ -47,14 +44,14 @@ export default function LoginScreen() {
     login(
       { phoneNumber, idNumber },
       {
-        onSuccess: async (data) => {
+        onSuccess: (data) => {
           if (data.status === 200) {
-            await setSession({
-              accessToken: data.body.accessToken,
-              salesforceUserId: data.body.salesforceUserId,
+            // The user exists. Move to SMS verification, carrying the phone
+            // and ID so that screen can run the Firebase phone-auth step.
+            router.push({
+              pathname: '/verify-sms',
+              params: { phoneNumber, idNumber },
             });
-            await queryClient.invalidateQueries();
-            router.replace('/(tabs)/activities');
             return;
           }
           const apiError = classifyApiError({ data });

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -8,32 +8,109 @@ import {
   StyleSheet,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
+import { FirebaseRecaptchaVerifierModal } from 'expo-firebase-recaptcha';
+import {
+  signInWithPhoneNumber,
+  type ApplicationVerifier,
+  type ConfirmationResult,
+} from 'firebase/auth';
+import { FirebaseError } from 'firebase/app';
+import { auth, firebaseConfig } from '../firebase/config';
 
-// TODO(feat/firebase-sms-login): when this screen mounts, trigger the Firebase
-// phone-auth SMS via signInWithPhoneNumber(phoneNumber) (with the recaptcha
-// verifier) and keep the resulting confirmationResult for handleVerify below.
-// idNumber is carried here so the eligibility check can be tied to the code.
+// Israeli mobile numbers arrive as 10 local digits (e.g. 0501234567); Firebase
+// Phone Auth needs E.164 format (+972501234567).
+function toE164(phone: string): string {
+  return '+972' + phone.replace(/^0/, '');
+}
+
+function verifyErrorMessage(err: unknown): string {
+  if (
+    err instanceof FirebaseError &&
+    (err.code === 'auth/invalid-verification-code' ||
+      err.code === 'auth/code-expired')
+  ) {
+    return 'הקוד שגוי או שפג תוקפו. נסה שוב.';
+  }
+  return 'אירעה שגיאה באימות הקוד. נסה שוב.';
+}
 
 export default function VerifySmsScreen() {
   const { phoneNumber } = useLocalSearchParams<{
     phoneNumber: string;
     idNumber: string;
   }>();
-  const [code, setCode] = useState('');
 
-  const handleVerify = () => {
-    // TODO(feat/firebase-sms-login): confirm `code` against the Firebase
-    // confirmationResult, then call /auth/session with the Firebase token,
-    // setSession(...), and router.replace('/(tabs)/activities').
+  const recaptchaVerifier = useRef<FirebaseRecaptchaVerifierModal>(null);
+  const [confirmation, setConfirmation] = useState<ConfirmationResult | null>(
+    null,
+  );
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [verified, setVerified] = useState(false);
+
+  const sendSms = useCallback(async () => {
+    if (!phoneNumber || !recaptchaVerifier.current) return;
+    setError(null);
+    setSending(true);
+    try {
+      const result = await signInWithPhoneNumber(
+        auth,
+        toE164(phoneNumber),
+        recaptchaVerifier.current as ApplicationVerifier,
+      );
+      setConfirmation(result);
+      console.log('[verify-sms] SMS sent');
+    } catch {
+      setError('שליחת קוד האימות נכשלה. נסה שוב.');
+    } finally {
+      setSending(false);
+    }
+  }, [phoneNumber]);
+
+  // Send the verification SMS once when the screen opens.
+  useEffect(() => {
+    void sendSms();
+  }, [sendSms]);
+
+  const handleVerify = async () => {
+    if (!confirmation) return;
+    setError(null);
+    setVerifying(true);
+    try {
+      const cred = await confirmation.confirm(code);
+      console.log('[verify-sms] code confirmed');
+      const idToken = await cred.user.getIdToken();
+      console.log('[verify-sms] Firebase ID token:', idToken);
+      setVerified(true);
+      // TODO(Step C): send idToken to POST /auth/session, then setSession(...)
+      // and router.replace('/(tabs)/activities').
+    } catch (err) {
+      setError(verifyErrorMessage(err));
+    } finally {
+      setVerifying(false);
+    }
   };
+
+  const verifyDisabled =
+    code.length !== 6 || verifying || !confirmation || verified;
 
   return (
     <SafeAreaView style={styles.container}>
+      <FirebaseRecaptchaVerifierModal
+        ref={recaptchaVerifier}
+        firebaseConfig={firebaseConfig}
+        attemptInvisibleVerification
+      />
       <View>
         <Text style={styles.title}>אימות מספר טלפון</Text>
-        <Text style={styles.subText}>
-          הזן את הקוד שנשלח ל-{phoneNumber}
-        </Text>
+        <Text style={styles.subText}>הזן את הקוד שנשלח ל-{phoneNumber}</Text>
+
+        {error && <Text style={styles.errorText}>{error}</Text>}
+        {verified && (
+          <Text style={styles.successText}>המספר אומת בהצלחה ✓</Text>
+        )}
 
         <View style={styles.inputContainer}>
           <Text style={styles.label}>קוד אימות</Text>
@@ -43,19 +120,28 @@ export default function VerifySmsScreen() {
             onChangeText={setCode}
             keyboardType="numeric"
             maxLength={6}
+            editable={!verified}
           />
         </View>
+
+        <TouchableOpacity onPress={sendSms} disabled={sending || verified}>
+          <Text style={styles.linkText}>
+            {sending ? 'שולח קוד...' : 'שליחת קוד מחדש'}
+          </Text>
+        </TouchableOpacity>
 
         <TouchableOpacity onPress={() => router.back()}>
           <Text style={styles.linkText}>חזרה</Text>
         </TouchableOpacity>
 
         <TouchableOpacity
-          style={[styles.verifyButton, code.length !== 6 && { opacity: 0.6 }]}
-          disabled={code.length !== 6}
+          style={[styles.verifyButton, verifyDisabled && { opacity: 0.6 }]}
+          disabled={verifyDisabled}
           onPress={handleVerify}
         >
-          <Text style={styles.verifyButtonText}>אמת</Text>
+          <Text style={styles.verifyButtonText}>
+            {verifying ? 'מאמת...' : 'אמת'}
+          </Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -104,5 +190,17 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 18,
     fontWeight: 'bold',
+  },
+  errorText: {
+    color: 'red',
+    textAlign: 'center' as const,
+    marginHorizontal: 15,
+    marginBottom: 10,
+  },
+  successText: {
+    color: 'green',
+    textAlign: 'center' as const,
+    marginHorizontal: 15,
+    marginBottom: 10,
   },
 });

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -76,7 +76,6 @@ export default function VerifySmsScreen() {
         verifier,
       );
       setConfirmation(result);
-      console.log('[verify-sms] SMS sent');
     } catch {
       setError('שליחת קוד האימות נכשלה. נסה שוב.');
     } finally {
@@ -95,9 +94,7 @@ export default function VerifySmsScreen() {
     setVerifying(true);
     try {
       const cred = await confirmation.confirm(code);
-      console.log('[verify-sms] code confirmed');
       const idToken = await cred.user.getIdToken();
-      console.log('[verify-sms] Firebase ID token:', idToken);
 
       // Finalize the session: the server verifies the token and sets the
       // salesforceUserId custom claim; it returns { ok: true } (no token).
@@ -106,29 +103,15 @@ export default function VerifySmsScreen() {
         idToken,
       });
       if (res.status !== 200) {
-        console.log(
-          '[verify-sms] /auth/session failed:',
-          res.status,
-          res.body,
-        );
         setError('סיום ההתחברות נכשל. נסה שוב.');
         return;
       }
 
       // Force-refresh so the new ID token carries the salesforceUserId claim
-      // the server just set. getIdTokenResult(true) refreshes AND returns the
-      // decoded claims, so we can confirm the claim actually landed. (Caching
-      // this token is the next step.)
-      const refreshed = await cred.user.getIdTokenResult(true);
-      console.log('[verify-sms] token changed:', refreshed.token !== idToken);
-      console.log(
-        '[verify-sms] salesforceUserId claim:',
-        refreshed.claims.salesforceUserId,
-      );
-
-      // Store the refreshed Firebase ID token as the app session — protected
-      // API calls attach it as the Bearer token.
-      await setSession(refreshed.token);
+      // the server just set, then store it as the app session — protected API
+      // calls attach it as the Bearer token.
+      const refreshedToken = await cred.user.getIdToken(true);
+      await setSession(refreshedToken);
 
       router.replace('/(tabs)/activities');
     } catch (err) {

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  SafeAreaView,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+
+// TODO(feat/firebase-sms-login): when this screen mounts, trigger the Firebase
+// phone-auth SMS via signInWithPhoneNumber(phoneNumber) (with the recaptcha
+// verifier) and keep the resulting confirmationResult for handleVerify below.
+// idNumber is carried here so the eligibility check can be tied to the code.
+
+export default function VerifySmsScreen() {
+  const { phoneNumber } = useLocalSearchParams<{
+    phoneNumber: string;
+    idNumber: string;
+  }>();
+  const [code, setCode] = useState('');
+
+  const handleVerify = () => {
+    // TODO(feat/firebase-sms-login): confirm `code` against the Firebase
+    // confirmationResult, then call /auth/session with the Firebase token,
+    // setSession(...), and router.replace('/(tabs)/activities').
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View>
+        <Text style={styles.title}>אימות מספר טלפון</Text>
+        <Text style={styles.subText}>
+          הזן את הקוד שנשלח ל-{phoneNumber}
+        </Text>
+
+        <View style={styles.inputContainer}>
+          <Text style={styles.label}>קוד אימות</Text>
+          <TextInput
+            style={styles.input}
+            value={code}
+            onChangeText={setCode}
+            keyboardType="numeric"
+            maxLength={6}
+          />
+        </View>
+
+        <TouchableOpacity onPress={() => router.back()}>
+          <Text style={styles.linkText}>חזרה</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.verifyButton, code.length !== 6 && { opacity: 0.6 }]}
+          disabled={code.length !== 6}
+          onPress={handleVerify}
+        >
+          <Text style={styles.verifyButtonText}>אמת</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    textAlign: 'right',
+    marginRight: 20,
+    marginTop: 40,
+  },
+  subText: {
+    fontSize: 18,
+    textAlign: 'right',
+    marginRight: 20,
+    marginBottom: 20,
+  },
+  inputContainer: { marginHorizontal: 20, marginBottom: 15 },
+  label: {
+    textAlign: 'right' as const,
+    fontSize: 14,
+    marginBottom: 6,
+    color: '#333',
+  },
+  input: {
+    borderBottomWidth: 1,
+    borderBottomColor: '#ccc',
+    paddingVertical: 8,
+    fontSize: 16,
+    textAlign: 'right' as const,
+  },
+  linkText: { textAlign: 'center', marginTop: 20, color: '#666' },
+  verifyButton: {
+    backgroundColor: '#FF8C00',
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 20,
+    marginHorizontal: 20,
+  },
+  verifyButtonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -17,6 +17,7 @@ import {
 import { FirebaseError } from 'firebase/app';
 import { auth, firebaseConfig } from '../firebase/config';
 import { useCreateSession } from '../api/hooks';
+import { setSession } from '../api/session';
 
 // Israeli mobile numbers arrive as 10 local digits (e.g. 0501234567); Firebase
 // Phone Auth needs E.164 format (+972501234567).
@@ -124,6 +125,10 @@ export default function VerifySmsScreen() {
         '[verify-sms] salesforceUserId claim:',
         refreshed.claims.salesforceUserId,
       );
+
+      // Store the refreshed Firebase ID token as the app session — protected
+      // API calls attach it as the Bearer token.
+      await setSession(refreshed.token);
 
       router.replace('/(tabs)/activities');
     } catch (err) {

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -16,6 +16,7 @@ import {
 } from 'firebase/auth';
 import { FirebaseError } from 'firebase/app';
 import { auth, firebaseConfig } from '../firebase/config';
+import { useCreateSession } from '../api/hooks';
 
 // Israeli mobile numbers arrive as 10 local digits (e.g. 0501234567); Firebase
 // Phone Auth needs E.164 format (+972501234567).
@@ -35,7 +36,7 @@ function verifyErrorMessage(err: unknown): string {
 }
 
 export default function VerifySmsScreen() {
-  const { phoneNumber } = useLocalSearchParams<{
+  const { phoneNumber, idNumber } = useLocalSearchParams<{
     phoneNumber: string;
     idNumber: string;
   }>();
@@ -48,7 +49,7 @@ export default function VerifySmsScreen() {
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [verifying, setVerifying] = useState(false);
-  const [verified, setVerified] = useState(false);
+  const { mutateAsync: createSession } = useCreateSession();
 
   const sendSms = useCallback(async () => {
     if (!phoneNumber) return;
@@ -96,9 +97,35 @@ export default function VerifySmsScreen() {
       console.log('[verify-sms] code confirmed');
       const idToken = await cred.user.getIdToken();
       console.log('[verify-sms] Firebase ID token:', idToken);
-      setVerified(true);
-      // TODO(Step C): send idToken to POST /auth/session, then setSession(...)
-      // and router.replace('/(tabs)/activities').
+
+      // Finalize the session: the server verifies the token and sets the
+      // salesforceUserId custom claim; it returns { ok: true } (no token).
+      const res = await createSession({
+        body: { phoneNumber, idNumber },
+        idToken,
+      });
+      if (res.status !== 200) {
+        console.log(
+          '[verify-sms] /auth/session failed:',
+          res.status,
+          res.body,
+        );
+        setError('סיום ההתחברות נכשל. נסה שוב.');
+        return;
+      }
+
+      // Force-refresh so the new ID token carries the salesforceUserId claim
+      // the server just set. getIdTokenResult(true) refreshes AND returns the
+      // decoded claims, so we can confirm the claim actually landed. (Caching
+      // this token is the next step.)
+      const refreshed = await cred.user.getIdTokenResult(true);
+      console.log('[verify-sms] token changed:', refreshed.token !== idToken);
+      console.log(
+        '[verify-sms] salesforceUserId claim:',
+        refreshed.claims.salesforceUserId,
+      );
+
+      router.replace('/(tabs)/activities');
     } catch (err) {
       setError(verifyErrorMessage(err));
     } finally {
@@ -106,8 +133,7 @@ export default function VerifySmsScreen() {
     }
   };
 
-  const verifyDisabled =
-    code.length !== 6 || verifying || !confirmation || verified;
+  const verifyDisabled = code.length !== 6 || verifying || !confirmation;
 
   return (
     <SafeAreaView style={styles.container}>
@@ -123,9 +149,6 @@ export default function VerifySmsScreen() {
         <Text style={styles.subText}>הזן את הקוד שנשלח ל-{phoneNumber}</Text>
 
         {error && <Text style={styles.errorText}>{error}</Text>}
-        {verified && (
-          <Text style={styles.successText}>המספר אומת בהצלחה ✓</Text>
-        )}
 
         <View style={styles.inputContainer}>
           <Text style={styles.label}>קוד אימות</Text>
@@ -135,11 +158,10 @@ export default function VerifySmsScreen() {
             onChangeText={setCode}
             keyboardType="numeric"
             maxLength={6}
-            editable={!verified}
           />
         </View>
 
-        <TouchableOpacity onPress={sendSms} disabled={sending || verified}>
+        <TouchableOpacity onPress={sendSms} disabled={sending}>
           <Text style={styles.linkText}>
             {sending ? 'שולח קוד...' : 'שליחת קוד מחדש'}
           </Text>
@@ -208,12 +230,6 @@ const styles = StyleSheet.create({
   },
   errorText: {
     color: 'red',
-    textAlign: 'center' as const,
-    marginHorizontal: 15,
-    marginBottom: 10,
-  },
-  successText: {
-    color: 'green',
     textAlign: 'center' as const,
     marginHorizontal: 15,
     marginBottom: 10,

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -51,14 +51,27 @@ export default function VerifySmsScreen() {
   const [verified, setVerified] = useState(false);
 
   const sendSms = useCallback(async () => {
-    if (!phoneNumber || !recaptchaVerifier.current) return;
+    if (!phoneNumber) return;
+    // expo-firebase-recaptcha's WebView verifier hangs on this project's
+    // Enterprise→v2 reCAPTCHA fallback. In dev, bypass it with a stub verifier;
+    // paired with appVerificationDisabledForTesting + a registered Firebase
+    // test number, signInWithPhoneNumber resolves with no WebView. Prod uses
+    // the modal.
+    const verifier = __DEV__
+      ? ({
+          type: 'recaptcha',
+          verify: () => Promise.resolve('test'),
+          _reset: () => undefined, // SDK calls _reset() in a finally block
+        } as unknown as ApplicationVerifier)
+      : (recaptchaVerifier.current as ApplicationVerifier | null);
+    if (!verifier) return;
     setError(null);
     setSending(true);
     try {
       const result = await signInWithPhoneNumber(
         auth,
         toE164(phoneNumber),
-        recaptchaVerifier.current as ApplicationVerifier,
+        verifier,
       );
       setConfirmation(result);
       console.log('[verify-sms] SMS sent');
@@ -98,11 +111,13 @@ export default function VerifySmsScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <FirebaseRecaptchaVerifierModal
-        ref={recaptchaVerifier}
-        firebaseConfig={firebaseConfig}
-        attemptInvisibleVerification
-      />
+      {!__DEV__ && (
+        <FirebaseRecaptchaVerifierModal
+          ref={recaptchaVerifier}
+          firebaseConfig={firebaseConfig}
+          attemptInvisibleVerification
+        />
+      )}
       <View>
         <Text style={styles.title}>אימות מספר טלפון</Text>
         <Text style={styles.subText}>הזן את הקוד שנשלח ל-{phoneNumber}</Text>

--- a/apps/mobile/src/firebase/config.ts
+++ b/apps/mobile/src/firebase/config.ts
@@ -1,11 +1,21 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-const firebaseConfig = {
-    apiKey: "AIzaSyAjMYuzz_-NXgFyP2XslePuyaRga25dYAs",
-    authDomain: "mandalat-halev-app.firebaseapp.com",
-    projectId: "mandalat-halev-app",
-    storageBucket: "mandalat-halev-app.firebasestorage.app",
-    messagingSenderId: "742059784204",
-    appId: "1:742059784204:web:52219444a2f9e5fead9629",
-    measurementId: "G-QBCBFW0JG3"
-  };
+export const firebaseConfig = {
+  apiKey: 'AIzaSyAjMYuzz_-NXgFyP2XslePuyaRga25dYAs',
+  authDomain: 'mandalat-halev-app.firebaseapp.com',
+  projectId: 'mandalat-halev-app',
+  storageBucket: 'mandalat-halev-app.firebasestorage.app',
+  messagingSenderId: '742059784204',
+  appId: '1:742059784204:web:52219444a2f9e5fead9629',
+  measurementId: 'G-QBCBFW0JG3',
+};
+
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+
+// getAuth uses in-memory persistence on React Native (logs a one-time warning).
+// That is fine for the SMS verification flow, which only needs a one-shot ID
+// token; AsyncStorage-backed persistence can be added later if sessions need it.
+export const auth = getAuth(app);

--- a/apps/mobile/src/firebase/config.ts
+++ b/apps/mobile/src/firebase/config.ts
@@ -19,3 +19,9 @@ const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 // That is fine for the SMS verification flow, which only needs a one-shot ID
 // token; AsyncStorage-backed persistence can be added later if sessions need it.
 export const auth = getAuth(app);
+
+// Dev only: lets Firebase test phone numbers skip real reCAPTCHA. __DEV__ is
+// false in production builds, so live users are unaffected.
+if (__DEV__) {
+  auth.settings.appVerificationDisabledForTesting = true;
+}

--- a/apps/server/src/app/client-app/auth/auth.service.ts
+++ b/apps/server/src/app/client-app/auth/auth.service.ts
@@ -1,20 +1,31 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  UnauthorizedException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import * as admin from 'firebase-admin';
 
 @Injectable()
 export class AuthService {
   async createSession(firebaseToken: string) {
+    let uid: string;
     try {
       const decodedToken = await admin.auth().verifyIdToken(firebaseToken);
-      const { uid } = decodedToken;
-
-      const salesforceUserId = 'MOCK_SF_USER_123';
-
-      await admin.auth().setCustomUserClaims(uid, { salesforceUserId });
-
-      return { ok: true as const };
-    } catch {
+      uid = decodedToken.uid;
+    } catch (err) {
+      Logger.error('[auth/session] verifyIdToken failed', err);
       throw new UnauthorizedException('Invalid Firebase token');
+    }
+
+    try {
+      await admin
+        .auth()
+        .setCustomUserClaims(uid, { salesforceUserId: 'MOCK_SF_USER_123' });
+      return { ok: true as const };
+    } catch (err) {
+      Logger.error('[auth/session] setCustomUserClaims failed', err);
+      throw new InternalServerErrorException('Failed to finalize session');
     }
   }
 }

--- a/apps/server/src/app/client-app/auth/firebase-admin.init.ts
+++ b/apps/server/src/app/client-app/auth/firebase-admin.init.ts
@@ -1,15 +1,42 @@
 import * as admin from 'firebase-admin';
 import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+
+// A service-account private key is a multi-line PEM. Stored in an env var it can
+// arrive escaped (\n, \r\n) or wrapped in stray quotes/whitespace; any of these
+// breaks OpenSSL with "DECODER routines::unsupported". Un-escape newlines, then
+// extract just the PEM block so whatever surrounds it is discarded.
+const normalizePrivateKey = (raw?: string): string | undefined => {
+  if (!raw) return raw;
+  const unescaped = raw
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\r/g, '');
+  const pem = unescaped.match(/-----BEGIN[^-]+-----[\s\S]+?-----END[^-]+-----/);
+  return pem ? `${pem[0]}\n` : unescaped.trim();
+};
 
 export const initializeFirebaseAdmin = (configService: ConfigService) => {
   if (admin.apps.length > 0) {
     return admin.app();
   }
 
+  const privateKey = normalizePrivateKey(
+    configService.get<string>('FIREBASE_PRIVATE_KEY'),
+  );
+
+  // Structural check only — does NOT log the key contents.
+  Logger.log(
+    `[firebase-admin] private key: length=${privateKey?.length ?? 0} ` +
+      `header=${privateKey?.startsWith('-----BEGIN') ?? false} ` +
+      `footer=${privateKey?.trimEnd().endsWith('PRIVATE KEY-----') ?? false} ` +
+      `lines=${privateKey?.split('\n').length ?? 0}`,
+  );
+
   const serviceAccount = {
     projectId: configService.get<string>('FIREBASE_PROJECT_ID'),
     clientEmail: configService.get<string>('FIREBASE_CLIENT_EMAIL'),
-    privateKey: configService.get<string>('FIREBASE_PRIVATE_KEY')?.replace(/\\n/g, '\n'),
+    privateKey,
   };
 
   return admin.initializeApp({

--- a/apps/server/src/app/client-app/auth/firebase-admin.init.ts
+++ b/apps/server/src/app/client-app/auth/firebase-admin.init.ts
@@ -1,6 +1,5 @@
 import * as admin from 'firebase-admin';
 import { ConfigService } from '@nestjs/config';
-import { Logger } from '@nestjs/common';
 
 // A service-account private key is a multi-line PEM. Stored in an env var it can
 // arrive escaped (\n, \r\n) or wrapped in stray quotes/whitespace; any of these
@@ -23,14 +22,6 @@ export const initializeFirebaseAdmin = (configService: ConfigService) => {
 
   const privateKey = normalizePrivateKey(
     configService.get<string>('FIREBASE_PRIVATE_KEY'),
-  );
-
-  // Structural check only — does NOT log the key contents.
-  Logger.log(
-    `[firebase-admin] private key: length=${privateKey?.length ?? 0} ` +
-      `header=${privateKey?.startsWith('-----BEGIN') ?? false} ` +
-      `footer=${privateKey?.trimEnd().endsWith('PRIVATE KEY-----') ?? false} ` +
-      `lines=${privateKey?.split('\n').length ?? 0}`,
   );
 
   const serviceAccount = {

--- a/libs/shared/src/lib/user_schemas.ts
+++ b/libs/shared/src/lib/user_schemas.ts
@@ -64,6 +64,14 @@ export const LoginResponseSchema = z.object({
 export type LoginRequestDto = z.infer<typeof LoginRequestSchema>;
 export type LoginResponseDto = z.infer<typeof LoginResponseSchema>;
 
+// Input for the create-session hook: the /auth/session request body
+// (LoginRequestSchema) plus the Firebase ID token, which is sent as a Bearer
+// header rather than in the body.
+export type CreateSessionDto = {
+  body: LoginRequestDto;
+  idToken: string;
+};
+
 /**
  * USER INFO SCHEMAS
  */
@@ -87,7 +95,7 @@ export const ContactSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   idNumber: z.string(),
-  birthDate: z.string(), 
+  birthDate: z.string(),
 });
 export type ContactDto = z.infer<typeof ContactSchema>;
 


### PR DESCRIPTION
## Summary

Adds Firebase phone-number (SMS) authentication for the mobile app, replacing the previous "JWT from the backend" login. The user signs in with their phone number and ID, verifies an SMS code through Firebase, and the backend finalizes the session by attaching a Salesforce custom claim to the Firebase user.

## Login flow

1. **Login screen** — collects phone number + ID and calls `POST /auth/login`. A `200 { ok: true }` means the user exists; the app navigates to a new SMS verification screen, carrying the phone/ID.
2. **SMS verification screen** (`verify-sms.tsx`, new) — sends an SMS code via Firebase Phone Auth (`signInWithPhoneNumber`); the user enters the 6-digit code and `confirm()` signs them into Firebase.
3. **Finalize session** — `POST /auth/session` with the Firebase ID token as a Bearer header plus the phone/ID body. The server verifies the token and sets a `salesforceUserId` custom claim; the client force-refreshes the token so it carries the claim, then enters the app.
4. **API authentication** — protected requests attach `Authorization: Bearer <firebaseIdToken>`. The token is stored in Expo SecureStore; expired tokens refresh automatically via Firebase; on a 401 the client force-refreshes and retries once.

## Changes

### Mobile (`apps/mobile`)
- `login.tsx` — on `200`, navigate to the SMS verification screen instead of storing a backend token.
- `verify-sms.tsx` — new screen: send SMS, confirm code, call `/auth/session`, refresh the token, enter the app.
- `firebase/config.ts` — initialize the Firebase client SDK. In dev, `appVerificationDisabledForTesting` is enabled so Firebase test phone numbers work in the simulator.
- `api/session.ts` — store the Firebase ID token in Expo SecureStore (mobile only); `getValidToken()` returns a current token from Firebase.
- `api/client.ts` — the protected client attaches the token and force-refreshes + retries on a 401.
- `api/hooks.ts` — `useCreateSession` hook for `/auth/session`.
- `(tabs)/_layout.tsx` — logout button in the header.

### Server (`apps/server`)
- `auth.service.ts` — `createSession` verifies the Firebase ID token and sets the `salesforceUserId` custom claim, with separate handling for an invalid token (401) vs a claim-write failure (500).
- `firebase-admin.init.ts` — normalize the service-account private key (extract the PEM block) so it parses regardless of how newlines/quotes survived env-var storage.

### Shared (`libs/shared`)
- `CreateSessionDto` type for the create-session request.

Also ignores the local `.claude/` directory.

## Notes

- reCAPTCHA: production uses `FirebaseRecaptchaVerifierModal`; dev uses a stub verifier with test phone numbers. `expo-firebase-recaptcha` is deprecated, so production reCAPTCHA may need a follow-up.
- Firebase Auth uses in-memory persistence; persisting the Firebase user across cold app restarts is a follow-up.
- The `apps/mobile/src/api/*.spec.ts` tests are stale against the current `{ ok: true }` login contract and need a separate update.