### PR TITLE
Man 29 ux activities registration fixes

### DIFF
--- a/apps/mobile/src/api/hooks.ts
+++ b/apps/mobile/src/api/hooks.ts
@@ -104,3 +104,23 @@ export function useRegistrationStatus(campaignId: string) {
       }),
   });
 }
+
+export function useRegisteredMembers(campaignId: string) {
+  return useQuery({
+    queryKey: ['campaigns', 'registeredMembers', campaignId],
+    queryFn: () =>
+      api.campaigns.registeredMembers({
+        query: { campaignId },
+      }),
+  });
+}
+
+export function useUnregisteredContacts(campaignId: string) {
+  return useQuery({
+    queryKey: ['campaigns', 'unregisteredContacts', campaignId],
+    queryFn: () =>
+      api.campaigns.unregisteredContacts({
+        query: { campaignId },
+      }),
+  });
+}

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -165,6 +165,8 @@ export default function ActivitiesScreen() {
   const { data: contactsData, isPending: contactsLoading } = useUserContacts();
   const contacts = contactsData?.status === 200 ? contactsData.body : [];
 
+  const [searchQuery, setSearchQuery] = useState('');
+
   // State for the post-registration notification popup.
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
@@ -189,6 +191,12 @@ export default function ActivitiesScreen() {
     return <QueryErrorState onRetry={refetch} />;
   }
 
+  const campaigns = data.body;
+  const trimmed = searchQuery.trim();
+  const filteredCampaigns = trimmed
+    ? campaigns.filter((c) => c.name.toLowerCase().includes(trimmed.toLowerCase()))
+    : campaigns;
+
   return (
     <SafeAreaView style={styles.safe}>
       <View style={styles.header}>
@@ -197,12 +205,14 @@ export default function ActivitiesScreen() {
           placeholder="חיפוש..."
           textAlign="right"
           style={styles.searchInput}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
         />
       </View>
 
       {/* Efficiently renders only the campaign cards currently visible on screen. */}
       <FlatList
-        data={data.body}
+        data={filteredCampaigns}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
           <ActiveCampaignItem
@@ -214,7 +224,11 @@ export default function ActivitiesScreen() {
           />
         )}
         ListEmptyComponent={
-          <Text style={styles.emptyText}>לא נמצאו פעילויות תואמות לחיפוש.</Text>
+          <Text style={styles.emptyText}>
+            {campaigns.length === 0
+              ? 'אין פעילויות זמינות כרגע.'
+              : 'לא נמצאו פעילויות תואמות לחיפוש'}
+          </Text>
         }
       />
 

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { FlatList, SafeAreaView, Text, StyleSheet, ActivityIndicator, Modal, TouchableOpacity, View } from 'react-native';
-import { useFutureCampaigns, useUserContacts } from '../../../api/hooks';
+import { useFutureCampaigns } from '../../../api/hooks';
 import { FutureCampaignItem } from '../../../components/FutureCampaignItem';
 import { CampaignDetailsModal } from '../../../components/CampaignDetailsModal';
 import { QueryErrorState } from '../../../components/QueryErrorState';
@@ -8,8 +8,6 @@ import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interface
 
 export default function FutureActivitiesScreen() {
   const { data, isPending, isError, refetch } = useFutureCampaigns();
-  const { data: contactsData, isPending: contactsLoading } = useUserContacts();
-  const contacts = contactsData?.status === 200 ? contactsData.body : [];
   const [modalVisible, setModalVisible] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
   const [selectedCampaign, setSelectedCampaign] = useState<GetFutureCampaignDto | null>(null);
@@ -41,8 +39,6 @@ export default function FutureActivitiesScreen() {
         renderItem={({ item }) => (
           <FutureCampaignItem
             campaign={item}
-            contacts={contacts}
-            contactsLoading={contactsLoading}
             onShowModal={showModal}
             onPressDetails={() => setSelectedCampaign(item)}
           />

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -48,6 +48,9 @@ export default function FutureActivitiesScreen() {
           />
         )}
         contentContainerStyle={{ paddingBottom: 20, paddingHorizontal: 15 }}
+        ListEmptyComponent={
+          <Text style={styles.emptyText}>לא קיימות פעילויות עתידיות</Text>
+        }
       />
 
       <Modal visible={modalVisible} transparent={true} animationType="fade">
@@ -79,4 +82,5 @@ const styles = StyleSheet.create({
   modalText: { fontSize: 16, marginBottom: 20, textAlign: 'center' },
   closeButton: { backgroundColor: '#FF8C00', paddingVertical: 10, paddingHorizontal: 20, borderRadius: 8 },
   closeButtonText: { color: '#fff', fontWeight: 'bold' },
+  emptyText: { textAlign: 'center', marginTop: 30, color: '#666', fontSize: 16 },
 });

--- a/apps/mobile/src/app/(tabs)/my-activities/past.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/past.tsx
@@ -41,6 +41,9 @@ export default function PreviousActivitiesScreen() {
           />
         )}
         contentContainerStyle={{ paddingBottom: 20, paddingHorizontal: 15 }}
+        ListEmptyComponent={
+          <Text style={styles.emptyText}>לא קיימות פעילויות קודמות</Text>
+        }
       />
 
       <CampaignDetailsModal 
@@ -57,4 +60,5 @@ const styles = StyleSheet.create({
   center: { justifyContent: 'center', alignItems: 'center' },
   header: { padding: 15 },
   title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right' },
+  emptyText: { textAlign: 'center', marginTop: 30, color: '#666', fontSize: 16 },
 });

--- a/apps/mobile/src/app/(tabs)/personal-data.tsx
+++ b/apps/mobile/src/app/(tabs)/personal-data.tsx
@@ -25,6 +25,7 @@ export default function PersonalDataScreen() {
 
   const { data: contactsData } = useUserContacts();
   const contacts = contactsData?.status === 200 ? contactsData.body : [];
+  const familyContacts = contacts.filter((c) => c.salesforceUserId !== profile?.salesforceUserId);
 
   if (isPending) {
     return (
@@ -81,10 +82,10 @@ export default function PersonalDataScreen() {
         {/* Family Members */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>בני משפחה</Text>
-          {contacts.length === 0 ? (
+          {familyContacts.length === 0 ? (
             <Text style={styles.cardDetail}>אין בני משפחה רשומים</Text>
           ) : (
-            contacts.map((contact) => (
+            familyContacts.map((contact) => (
               <View key={contact.salesforceUserId} style={styles.card}>
                 <Text style={styles.cardName}>{contact.firstName} {contact.lastName}</Text>
                 <Text style={styles.cardDetail}>ת.ז. {contact.idNumber}</Text>

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Modal, ActivityIndicator } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { MyActivityItem } from './MyActivityItem';
-import { useRegisteredMembers, useUnregisterFromCampaign } from '../api/hooks';
+import { useRegisteredMembers, useUnregisteredContacts, useUnregisterFromCampaign, useRegisterForCampaign } from '../api/hooks';
 import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
 export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
@@ -13,6 +13,8 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
   const queryClient = useQueryClient();
   const [selectionVisible, setSelectionVisible] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [registerModalVisible, setRegisterModalVisible] = useState(false);
+  const [registerSelectedIds, setRegisterSelectedIds] = useState<string[]>([]);
 
   const {
     data: membersData,
@@ -22,6 +24,16 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
   } = useRegisteredMembers(campaign.id);
 
   const { mutate: unregister, isPending: isUnregistering } = useUnregisterFromCampaign();
+  const { mutate: register, isPending: isRegistering } = useRegisterForCampaign();
+
+  const {
+    data: unregisteredData,
+    isPending: unregisteredLoading,
+    isError: isUnregisteredError,
+    refetch: refetchUnregistered,
+  } = useUnregisteredContacts(campaign.id);
+
+  const unregisteredContacts = unregisteredData?.status === 200 ? unregisteredData.body.contacts : [];
 
   const members = membersData?.status === 200 ? membersData.body.registeredMembers : [];
 
@@ -77,6 +89,70 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
     performUnregister(selectedIds);
   };
 
+  const performRegister = (contactIds: string[]) => {
+    register(
+      { campaignId: campaign.id, contactIds },
+      {
+        onSuccess: (data) => {
+          if (data.status === 200 && data.body?.requestReceivedSuccessfully) {
+            onShowModal('בקשת ההרשמה נשלחה בהצלחה!');
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'future'] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'active'] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'registeredMembers', campaign.id] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'unregisteredContacts', campaign.id] });
+          } else {
+            const errorMessage = (data.body as any)?.message || 'אירעה שגיאה בהרשמה. אנא נסה שוב.';
+            onShowModal(errorMessage);
+          }
+        },
+        onError: () => onShowModal('שגיאת תקשורת או מערכת. אנא בדוק את החיבור ונסה שוב.'),
+      }
+    );
+  };
+
+  const handleRegisterMore = () => {
+    setRegisterSelectedIds([]);
+    setRegisterModalVisible(true);
+  };
+
+  const toggleRegisterContact = (id: string) => {
+    setRegisterSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const confirmRegister = () => {
+    setRegisterModalVisible(false);
+    performRegister(registerSelectedIds);
+  };
+
+  const renderRegisterAction = () => {
+    if (unregisteredLoading) {
+      return <ActivityIndicator size="small" color="#FF8C00" />;
+    }
+    if (isUnregisteredError || unregisteredData?.status !== 200) {
+      return (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>שגיאה בטעינת הנתונים</Text>
+          <TouchableOpacity onPress={() => refetchUnregistered()}>
+            <Text style={styles.retryText}>נסה שוב</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+    return (
+      <TouchableOpacity
+        style={[styles.registerButton, (isRegistering || unregisteredContacts.length === 0) && styles.disabledButton]}
+        onPress={handleRegisterMore}
+        disabled={isRegistering || unregisteredContacts.length === 0}
+      >
+        <Text style={styles.registerButtonText}>
+          {isRegistering ? 'נרשם...' : 'רישום משתתפים נוספים'}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+
   const renderAction = () => {
     if (membersLoading) {
       return <ActivityIndicator size="small" color="#ff4444" />;
@@ -115,9 +191,52 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
         onPressDetails={onPressDetails}
       >
         <View style={styles.actionContainer}>
+          {renderRegisterAction()}
           {renderAction()}
         </View>
       </MyActivityItem>
+
+      <Modal visible={registerModalVisible} transparent animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.selectionModal}>
+            <Text style={[styles.selectionTitle, styles.registerSelectionTitle]}>בחר משתתפים לרישום</Text>
+
+            {unregisteredContacts.map((contact) => {
+              const selected = registerSelectedIds.includes(contact.salesforceUserId);
+              return (
+                <TouchableOpacity
+                  key={contact.salesforceUserId}
+                  style={styles.contactRow}
+                  onPress={() => toggleRegisterContact(contact.salesforceUserId)}
+                >
+                  <Text style={styles.contactName}>
+                    {contact.firstName} {contact.lastName}
+                  </Text>
+                  <View style={[styles.checkbox, selected && styles.registerCheckboxSelected]}>
+                    {selected && <Text style={styles.checkmark}>✓</Text>}
+                  </View>
+                </TouchableOpacity>
+              );
+            })}
+
+            <View style={styles.selectionButtons}>
+              <TouchableOpacity
+                onPress={() => setRegisterModalVisible(false)}
+                style={styles.cancelButton}
+              >
+                <Text style={styles.cancelButtonText}>ביטול</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={confirmRegister}
+                disabled={registerSelectedIds.length === 0}
+                style={[styles.registerConfirmButton, registerSelectedIds.length === 0 && styles.disabledButton]}
+              >
+                <Text style={styles.confirmButtonText}>אישור</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
 
       <Modal visible={selectionVisible} transparent animationType="slide">
         <View style={styles.modalOverlay}>
@@ -165,7 +284,23 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
 }
 
 const styles = StyleSheet.create({
-  actionContainer: { alignItems: 'flex-end' },
+  actionContainer: { alignItems: 'flex-end', gap: 8 },
+  registerButton: {
+    backgroundColor: '#FF8C00',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+  },
+  registerButtonText: { color: '#fff', fontWeight: 'bold' },
+  registerSelectionTitle: { color: '#FF8C00' },
+  registerCheckboxSelected: { backgroundColor: '#FF8C00', borderColor: '#FF8C00' },
+  registerConfirmButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#FF8C00',
+    alignItems: 'center' as const,
+  },
   unregisterButton: {
     backgroundColor: '#ff4444',
     paddingVertical: 8,

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -1,59 +1,51 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Modal } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Modal, ActivityIndicator } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { MyActivityItem } from './MyActivityItem';
-import {
-  useRegistrationStatus,
-  useUnregisterFromCampaign
-} from '../api/hooks';
-import type { GetFutureCampaignDto, ContactDto } from '@mandalat-halev-project/api-interfaces';
+import { useRegisteredMembers, useUnregisterFromCampaign } from '../api/hooks';
+import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
 
-export function FutureCampaignItem({ campaign, contacts, contactsLoading, onShowModal, onPressDetails }: {
+export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
   campaign: GetFutureCampaignDto;
-  contacts: ContactDto[];
-  contactsLoading: boolean;
   onShowModal: (msg: string) => void;
   onPressDetails: () => void;
 }) {
   const queryClient = useQueryClient();
-  const [isUnregistered, setIsUnregistered] = useState(false);
   const [selectionVisible, setSelectionVisible] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   const {
-    data: statusData,
-    isPending: statusPending,
-    isFetching,
-    isError: isStatusError,
-  } = useRegistrationStatus(campaign.id);
+    data: membersData,
+    isPending: membersLoading,
+    isError: isMembersError,
+    refetch: refetchMembers,
+  } = useRegisteredMembers(campaign.id);
+
   const { mutate: unregister, isPending: isUnregistering } = useUnregisterFromCampaign();
 
+  const members = membersData?.status === 200 ? membersData.body.registeredMembers : [];
+
   let statusText: string;
-  if (statusPending || isFetching) {
+  if (membersLoading) {
     statusText = 'טוען...';
-  } else if (statusData?.status === 200) {
-    statusText = statusData.body.registrationStatus === 'approved' ? 'רשום' : 'מחכה לאישור';
-  } else if (isStatusError || statusData) {
+  } else if (isMembersError || membersData?.status !== 200) {
     statusText = 'שגיאה בטעינת הסטטוס';
+  } else if (members.length > 0) {
+    statusText = members.every((m) => m.registrationStatus === 'approved') ? 'רשום' : 'מחכה לאישור';
   } else {
     statusText = 'לא ידוע';
   }
 
-  if (isUnregistered) {
-    statusText = 'בוטל';
-  }
-
-  // Sends the unregistration request with the given contact IDs.
   const performUnregister = (contactIds: string[]) => {
     unregister(
       { campaignId: campaign.id, contactIds },
       {
         onSuccess: (data) => {
           if (data.status === 200 && data.body?.requestReceivedSuccessfully) {
-            setIsUnregistered(true);
             onShowModal('הרישום בוטל בהצלחה!');
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'future'] });
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'active'] });
+            queryClient.invalidateQueries({ queryKey: ['campaigns', 'registeredMembers', campaign.id] });
             queryClient.invalidateQueries({ queryKey: ['campaigns', 'registrationStatus', campaign.id] });
           } else {
             const errorMessage = (data.body as any)?.message || 'משהו השתבש בביטול ההרשמה. אנא נסה שוב.';
@@ -65,11 +57,9 @@ export function FutureCampaignItem({ campaign, contacts, contactsLoading, onShow
     );
   };
 
-  // If the user has only one contact (themselves), unregister immediately.
-  // If they have multiple contacts, open the selection modal.
   const handleUnregister = () => {
-    if (contacts.length <= 1) {
-      performUnregister(contacts.map((c) => c.salesforceUserId));
+    if (members.length <= 1) {
+      performUnregister(members.map((m) => m.salesforceUserId));
     } else {
       setSelectedIds([]);
       setSelectionVisible(true);
@@ -87,6 +77,34 @@ export function FutureCampaignItem({ campaign, contacts, contactsLoading, onShow
     performUnregister(selectedIds);
   };
 
+  const renderAction = () => {
+    if (membersLoading) {
+      return <ActivityIndicator size="small" color="#ff4444" />;
+    }
+    if (isMembersError || membersData?.status !== 200) {
+      return (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>שגיאה בטעינת הנתונים</Text>
+          <TouchableOpacity onPress={() => refetchMembers()}>
+            <Text style={styles.retryText}>נסה שוב</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+    if (members.length === 0) return null;
+    return (
+      <TouchableOpacity
+        style={[styles.unregisterButton, isUnregistering && styles.disabledButton]}
+        onPress={handleUnregister}
+        disabled={isUnregistering}
+      >
+        <Text style={styles.unregisterButtonText}>
+          {isUnregistering ? 'מבטל...' : 'ביטול רישום'}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+
   return (
     <>
       <MyActivityItem
@@ -97,36 +115,25 @@ export function FutureCampaignItem({ campaign, contacts, contactsLoading, onShow
         onPressDetails={onPressDetails}
       >
         <View style={styles.actionContainer}>
-          {!isUnregistered && (
-            <TouchableOpacity
-              style={[styles.unregisterButton, (isUnregistering || contactsLoading) && styles.disabledButton]}
-              onPress={handleUnregister}
-              disabled={isUnregistering || contactsLoading}
-            >
-              <Text style={styles.unregisterButtonText}>
-                {isUnregistering ? 'מבטל...' : 'ביטול רישום'}
-              </Text>
-            </TouchableOpacity>
-          )}
+          {renderAction()}
         </View>
       </MyActivityItem>
 
-      {/* Contact selection bottom sheet — only shown when the user has multiple contacts. */}
       <Modal visible={selectionVisible} transparent animationType="slide">
         <View style={styles.modalOverlay}>
           <View style={styles.selectionModal}>
             <Text style={styles.selectionTitle}>בחר משתתפים לביטול</Text>
 
-            {contacts.map((contact) => {
-              const selected = selectedIds.includes(contact.salesforceUserId);
+            {members.map((member) => {
+              const selected = selectedIds.includes(member.salesforceUserId);
               return (
                 <TouchableOpacity
-                  key={contact.salesforceUserId}
+                  key={member.salesforceUserId}
                   style={styles.contactRow}
-                  onPress={() => toggleContact(contact.salesforceUserId)}
+                  onPress={() => toggleContact(member.salesforceUserId)}
                 >
                   <Text style={styles.contactName}>
-                    {contact.firstName} {contact.lastName}
+                    {member.firstName} {member.lastName}
                   </Text>
                   <View style={[styles.checkbox, selected && styles.checkboxSelected]}>
                     {selected && <Text style={styles.checkmark}>✓</Text>}
@@ -142,7 +149,6 @@ export function FutureCampaignItem({ campaign, contacts, contactsLoading, onShow
               >
                 <Text style={styles.cancelButtonText}>ביטול</Text>
               </TouchableOpacity>
-              {/* Confirm is disabled when no contacts are selected. */}
               <TouchableOpacity
                 onPress={confirmUnregister}
                 disabled={selectedIds.length === 0}
@@ -168,6 +174,9 @@ const styles = StyleSheet.create({
   },
   disabledButton: { opacity: 0.6 },
   unregisterButtonText: { color: '#fff', fontWeight: 'bold' },
+  errorContainer: { alignItems: 'flex-end', gap: 4 },
+  errorText: { color: '#ff4444', fontSize: 13 },
+  retryText: { color: '#FF8C00', fontSize: 13, fontWeight: 'bold' },
   // Contact selection bottom sheet
   modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   selectionModal: {

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -3,7 +3,14 @@ import { View, Text, TouchableOpacity, StyleSheet, Modal, ActivityIndicator } fr
 import { useQueryClient } from '@tanstack/react-query';
 import { MyActivityItem } from './MyActivityItem';
 import { useRegisteredMembers, useUnregisteredContacts, useUnregisterFromCampaign, useRegisterForCampaign } from '../api/hooks';
-import type { GetFutureCampaignDto } from '@mandalat-halev-project/api-interfaces';
+import { Status } from './Status';
+import type { GetFutureCampaignDto, ApprovalStatus } from '@mandalat-halev-project/api-interfaces';
+
+const approvalStatusLabel = (status: ApprovalStatus): string => {
+  if (status === 'approved') return 'אושר';
+  if (status === 'rejected') return 'נדחה';
+  return 'מחכה לאישור';
+};
 
 export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
   campaign: GetFutureCampaignDto;
@@ -187,9 +194,19 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
         title={campaign.name}
         date={`${campaign.startDate} | ${campaign.durationInHours} שעות`}
         location={`${campaign.locationAddress}, ${campaign.locationCity}`}
-        status={statusText}
+        status={members.length > 1 ? undefined : statusText}
         onPressDetails={onPressDetails}
       >
+        {members.length > 1 && (
+          <View style={styles.memberStatusList}>
+            {members.map((m) => (
+              <View key={m.salesforceUserId} style={styles.memberStatusRow}>
+                <Status label={approvalStatusLabel(m.registrationStatus)} />
+                <Text style={styles.memberName}>{m.firstName} {m.lastName}</Text>
+              </View>
+            ))}
+          </View>
+        )}
         <View style={styles.actionContainer}>
           {renderRegisterAction()}
           {renderAction()}
@@ -284,6 +301,9 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
 }
 
 const styles = StyleSheet.create({
+  memberStatusList: { gap: 6, marginBottom: 4 },
+  memberStatusRow: { flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'center', gap: 8 },
+  memberName: { fontSize: 14, color: '#333', textAlign: 'right' },
   actionContainer: { alignItems: 'flex-end', gap: 8 },
   registerButton: {
     backgroundColor: '#FF8C00',

--- a/apps/mobile/src/components/MyActivityItem.tsx
+++ b/apps/mobile/src/components/MyActivityItem.tsx
@@ -7,7 +7,7 @@ interface MyActivityItemProps {
   title: string;
   date: string;
   location: string;
-  status: string;
+  status?: string;
   onPressDetails?: () => void;
   children?: React.ReactNode;
 }
@@ -26,7 +26,7 @@ export const MyActivityItem = ({
       <View style={styles.info}>
         {/* Status on left, name on right */}
         <View style={styles.nameRow}>
-          <Status label={status} />
+          {status ? <Status label={status} /> : null}
           <Text style={styles.title}>{title}</Text>
         </View>
 

--- a/apps/mobile/src/components/Status.tsx
+++ b/apps/mobile/src/components/Status.tsx
@@ -5,13 +5,13 @@ export const Status = ({ label }: { label: string }) => {
   let badgeStyle = styles.defaultBadge;
   let textStyle = styles.defaultText;
 
-  if (label === 'רשום' || label === 'נוכח') {
+  if (label === 'רשום' || label === 'נוכח' || label === 'אושר') {
     badgeStyle = styles.registeredBadge;
     textStyle = styles.registeredText;
-  } else if (label === 'מחכה לאישור') {
+  } else if (label === 'מחכה לאישור' || label === 'ברשימת המתנה') {
     badgeStyle = styles.pendingBadge;
     textStyle = styles.pendingText;
-  } else if (label === 'בוטל' || label === 'לא רשום' || label === 'לא נוכח') {
+  } else if (label === 'בוטל' || label === 'לא רשום' || label === 'לא נוכח' || label === 'נדחה') {
     badgeStyle = styles.cancelledBadge;
     textStyle = styles.cancelledText;
   }

--- a/libs/shared/src/lib/user_endpoints.ts
+++ b/libs/shared/src/lib/user_endpoints.ts
@@ -11,6 +11,7 @@ import {
   UnregisterFromCampaignSchema,
   RegisterResponseSchema,
   GetRegistrationStatusSchema,
+  CampaignMemberRegistrationSchema,
   ErrorResponseSchema,
   ValidationErrorResponseSchema,
   RegisterDeviceTokenSchema,
@@ -154,6 +155,38 @@ export const userContract = c.router({
         500: ErrorResponseSchema,
       },
       summary: 'Get registration status for a specific user and campaign',
+    },
+    registeredMembers: {
+      method: 'GET',
+      path: '/campaigns/registration-status',
+      query: z.object({
+        campaignId: z.coerce.string(),
+      }),
+      responses: {
+        200: z.object({ registeredMembers: z.array(CampaignMemberRegistrationSchema) }),
+        400: ValidationErrorResponseSchema,
+        401: ErrorResponseSchema,
+        403: ErrorResponseSchema,
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+      summary: 'Get all registered members for a campaign',
+    },
+    unregisteredContacts: {
+      method: 'GET',
+      path: '/campaigns/unregistered-contacts',
+      query: z.object({
+        campaignId: z.coerce.string(),
+      }),
+      responses: {
+        200: z.object({ contacts: z.array(ContactSchema) }),
+        400: ValidationErrorResponseSchema,
+        401: ErrorResponseSchema,
+        403: ErrorResponseSchema,
+        404: ErrorResponseSchema,
+        500: ErrorResponseSchema,
+      },
+      summary: 'Get household contacts not yet registered to a campaign',
     },
   },
   notifications: {

--- a/libs/shared/src/lib/user_schemas.ts
+++ b/libs/shared/src/lib/user_schemas.ts
@@ -176,6 +176,15 @@ export type GetRegistrationStatusDto = z.infer<
   typeof GetRegistrationStatusSchema
 >;
 
+export const CampaignMemberRegistrationSchema = ContactSchema.extend({
+  registrationStatus: ApprovalStatusSchema,
+  additionalInfo: z.string().optional(),
+});
+
+export type CampaignMemberRegistrationDto = z.infer<
+  typeof CampaignMemberRegistrationSchema
+>;
+
 /**
  * NOTIFICATIONS SCHEMAS
  */


### PR DESCRIPTION
Summary

API hooks: Added useRegisteredMembers and useUnregisteredContacts hooks backed by new shared contract entries (GET /campaigns/registration-status → { registeredMembers }, GET /campaigns/unregistered-contacts → { contacts })

Activities search: Wired the search field in the Available Activities screen with local searchQuery state; filters cached results by campaign name (case-insensitive). Two distinct empty states — no campaigns vs. no search match

Future/Past empty states: Added Hebrew empty copy for both tabs on 200 with empty array

Cancel registration: FutureCampaignItem now loads registered contacts via useRegisteredMembers instead of the full household contacts list. Single registered contact unregisters immediately; multiple opens a picker showing only registered contacts

Register more contacts: Added a second CTA (רישום משתתפים נוספים) that loads unregistered contacts via useUnregisteredContacts and opens a multi-select modal backed by the existing POST /campaigns/register

Per-contact status: When multiple contacts are registered, shows each contact's individual status badge (אושר / נדחה / מחכה לאישור) instead of one aggregate status for the card

Family list: Personal data screen filters out the logged-in user from the בני משפחה section