### PR TITLE
chore: configure mobile app for Google Play release

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,17 +1,18 @@
 {
   "expo": {
-    "name": "Mobile",
-    "slug": "mobile",
+    "name": "מנדלת הלב",
+    "slug": "mandalat-halev",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "mobile",
+    "scheme": "mandalat-halev",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true
     },
     "android": {
+      "package": "org.mandalathalev.app",
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
@@ -38,6 +39,14 @@
           "root": "./src/app"
         }
       ]
-    ]
+    ],
+    "extra": {
+      "router": {
+        "root": "./src/app"
+      },
+      "eas": {
+        "projectId": "42ffcae4-d4c6-4e52-a553-acd58bc4b853"
+      }
+    }
   }
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,6 +1,11 @@
 {
+  "cli": {
+    "appVersionSource": "remote"
+  },
   "build": {
     "production": {
+      "autoIncrement": true,
+      "environment": "production",
       "android": {
         "buildType": "app-bundle"
       }

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -10,13 +10,18 @@ if (process.env.EXPO_APP_TARGET === 'local') {
   envPaths.push(path.join(mobileDir, '.env.mobile.local'));
 }
 
-dotenvx.config({
-  path: envPaths,
-  envKeysFile: path.join(mobileDir, '.env.mobile.keys'),
-  ignore: ['MISSING_ENV_FILE'],
-  overload: true,
-  quiet: true,
-});
+// On EAS Build / CI, EXPO_PUBLIC_API_BASE_URL is injected directly as an env var and the
+// gitignored .env.mobile.keys decryption key isn't present. Skip dotenvx there so we don't
+// fail with MISSING_PRIVATE_KEY or clobber the injected value with the encrypted ciphertext.
+if (!process.env.EXPO_PUBLIC_API_BASE_URL) {
+  dotenvx.config({
+    path: envPaths,
+    envKeysFile: path.join(mobileDir, '.env.mobile.keys'),
+    ignore: ['MISSING_ENV_FILE'],
+    overload: true,
+    quiet: true,
+  });
+}
 
 const { withNxMetro } = require('@nx/expo');
 const { getDefaultConfig } = require('@expo/metro-config');

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "expo-router/entry",
   "scripts": {
-    "eas-build-post-install": "cd ../../ && node tools/scripts/eas-build-post-install.mjs . apps/mobile"
+    "eas-build-post-install": "cd ../../ && node tools/scripts/eas-build-post-install.mjs . apps/mobile && npx nx build @mandalat-halev-project/api-interfaces"
   },
   "nx": {
     "name": "mobile"


### PR DESCRIPTION
## Summary

Configure the mobile app for Google Play release and EAS production builds.

## Changes

* Update Expo app identity from the generic mobile app config to the real app name, slug, and scheme
* Add the Android package name required for Google Play distribution
* Link the mobile app to the EAS project
* Configure EAS production builds to use the production environment
* Enable remote app version management and automatic version incrementing for release builds
* Build the shared `api-interfaces` package during EAS post-install so remote builds can resolve shared API contracts
* Skip local `dotenvx` env loading when `EXPO_PUBLIC_API_BASE_URL` is already injected by EAS/CI, preventing missing key errors or accidental override of the injected production value

## Notes

These changes prepare the mobile app for Android release builds and Google Play testing/review. The production API base URL is expected to be provided through the EAS production environment.
