### PR TITLE
chore: add Expo owner to app config

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,5 +1,6 @@
 {
   "expo": {
+    "owner": "talaizen",
     "name": "מנדלת הלב",
     "slug": "mandalat-halev",
     "version": "1.0.0",


### PR DESCRIPTION
## Summary

Adds the Expo `owner` field to the mobile app config.

The Expo account `talaizen` was converted into an organization, so the app now needs to explicitly declare the Expo owner in `app.json`.

## Changes

- Added `"owner": "talaizen"` under the top-level `expo` config.

## Why

This ensures EAS CLI resolves the project under the correct Expo organization when running builds, especially for team members who log in with their own Expo accounts.

## Testing

- Verified this is the only config change.
- No app runtime behavior changed.