### PR TITLE
fix(MAN-31): Update Firestore initialization to use custom DB name

### DIFF
--- a/apps/server/src/app/client-app/notifications/notification-scheduler.service.ts
+++ b/apps/server/src/app/client-app/notifications/notification-scheduler.service.ts
@@ -9,6 +9,8 @@ import { NotificationTemplates } from './notification-copy';
 import { SalesforceCampaignService } from '../../salesforce/campaign/salesforce-campaign.service';
 import { SalesforceUserService } from '../../salesforce/user/salesforce-user.service';
 
+import { getFirestore } from 'firebase-admin/firestore';
+
 const ENABLE_NOTIFICATION_CRON = true;
 
 @Injectable()
@@ -130,7 +132,7 @@ export class NotificationSchedulerService {
   private async pollRegistrationStatusChanges() {
     this.logger.log('Polling Phase 3: Registration status changes...');
     const currentStatuses = await this.sfCampaignService.getUpcomingRegistrationStatuses();
-    const db = admin.firestore();
+    const db = getFirestore('mandalat-halev-app-db');
     const stateCollection = db.collection('registrationNotificationState');
     const now = new Date();
 
@@ -185,7 +187,7 @@ export class NotificationSchedulerService {
   }
 
   private async acquireFirestoreLock(): Promise<boolean> {
-    const db = admin.firestore();
+    const db = getFirestore('mandalat-halev-app-db');
     const lockRef = db.collection('cronLocks').doc('daily-notifications');
     
     try {
@@ -218,7 +220,7 @@ export class NotificationSchedulerService {
   }
 
   private async releaseFirestoreLock(): Promise<void> {
-    const db = admin.firestore();
+    const db = getFirestore('mandalat-halev-app-db');
     try {
       await db.collection('cronLocks').doc('daily-notifications').set({
         expiresAt: admin.firestore.Timestamp.fromDate(new Date(0)),

--- a/apps/server/src/app/client-app/notifications/push-token.repository.firestore.ts
+++ b/apps/server/src/app/client-app/notifications/push-token.repository.firestore.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@nestjs/common';
 import * as admin from 'firebase-admin';
 import { IPushTokenRepository, PushTokenRecord, NotificationPreferencesRecord } from './push-token.repository';
 
+import { getFirestore } from 'firebase-admin/firestore';
+
 @Injectable()
 export class FirestorePushTokenRepository implements IPushTokenRepository {
   
   private get collection() {
-    return admin.firestore().collection('pushTokens');
+    return getFirestore('mandalat-halev-app-db').collection('pushTokens');
   }
 
   async upsert(tokenData: Omit<PushTokenRecord, 'id' | 'updatedAt' | 'enabled' | 'preferences'>): Promise<PushTokenRecord> {
@@ -85,7 +87,7 @@ export class FirestorePushTokenRepository implements IPushTokenRepository {
   async deleteByToken(nativeToken: string): Promise<void> {
     const snapshot = await this.collection.where('nativeToken', '==', nativeToken).get();
     
-    const batch = admin.firestore().batch();
+    const batch = getFirestore('mandalat-halev-app-db').batch();
     snapshot.docs.forEach((doc) => {
       batch.delete(doc.ref);
     });


### PR DESCRIPTION
This PR fixes the Firestore connection issue in the Salesforce notification cron job. 
As noted in previous reviews, the project uses a custom Firestore database (`mandalat-halev-app-db`), but the code was previously using the default `admin.firestore()` initialization, which resulted in a `5 NOT_FOUND` error.

**Changes Made**
- Replaced `admin.firestore()` with `getFirestore('mandalat-halev-app-db')` across the relevant services (cron scheduler and push token repository) to point to the correct database and region.

**Testing**
- Triggered the cron orchestration manually via Postman.
- Verified successful execution (Status: 201 Created).
- Verified in Firebase Console that `cronLocks` and `registrationNotificationState` documents are successfully created and updated in the custom database.

<img width="688" height="454" alt="image" src="https://github.com/user-attachments/assets/52dfa761-aa1c-4164-8350-5120983f4e9d" />
<img width="686" height="454" alt="image" src="https://github.com/user-attachments/assets/d64aca02-0f8d-4880-9e75-cab790110519" />
