### PR TITLE
Man 33 fix closed testing UI feedback

### DIFF
--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -285,7 +285,7 @@ const styles = StyleSheet.create({
   selectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'auto',
     color: '#FF8C00',
     marginBottom: 16,
   },
@@ -308,7 +308,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#FF8C00',
     borderColor: '#FF8C00',
   },
-  contactName: { fontSize: 16, textAlign: 'right', flex: 1, paddingLeft: 12 },
+  contactName: { fontSize: 16, textAlign: 'auto', flex: 1, paddingLeft: 12 },
   checkmark: { color: '#fff', fontSize: 14, fontWeight: 'bold', textAlign: 'center' },
   selectionButtons: {
     flexDirection: 'row',

--- a/apps/mobile/src/app/(tabs)/activities.tsx
+++ b/apps/mobile/src/app/(tabs)/activities.tsx
@@ -92,6 +92,7 @@ function ActiveCampaignItem({ item, contacts, contactsLoading, onShowModal, onPr
         duration={`${item.durationInHours} שעות`}
         location={`${item.locationAddress}, ${item.locationCity}`}
         status={isRegistered ? 'נרשמת בהצלחה' : 'פתוח להרשמה'}
+        imageUrl={item.imageUrl}
         onPressDetails={onPressDetails}
       >
         <View style={styles.actionContainer}>

--- a/apps/mobile/src/app/(tabs)/my-activities/future.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/future.tsx
@@ -72,7 +72,7 @@ export default function FutureActivitiesScreen() {
 const styles = StyleSheet.create({
   safe: { flex: 1 },
   center: { justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', padding: 15 },
+  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'auto', padding: 15 },
   modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
   modalContent: { backgroundColor: '#fff', padding: 20, borderRadius: 10, width: '80%', alignItems: 'center' },
   modalText: { fontSize: 16, marginBottom: 20, textAlign: 'center' },

--- a/apps/mobile/src/app/(tabs)/my-activities/past.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/past.tsx
@@ -60,6 +60,6 @@ const styles = StyleSheet.create({
   safe: { flex: 1 },
   center: { justifyContent: 'center', alignItems: 'center' },
   header: { padding: 15 },
-  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right' },
+  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'auto' },
   emptyText: { textAlign: 'center', marginTop: 30, color: '#666', fontSize: 16 },
 });

--- a/apps/mobile/src/app/(tabs)/my-activities/past.tsx
+++ b/apps/mobile/src/app/(tabs)/my-activities/past.tsx
@@ -37,6 +37,7 @@ export default function PreviousActivitiesScreen() {
             date={`${item.startDate} | ${item.durationInHours} שעות`}
             location={`${item.locationAddress}, ${item.locationCity}`}
             status={item.hasUserParticipated ? 'נוכח' : 'לא נוכח'}
+            imageUrl={item.imageUrl}
             onPressDetails={() => setSelectedCampaign(item)}
           />
         )}

--- a/apps/mobile/src/app/(tabs)/personal-data.tsx
+++ b/apps/mobile/src/app/(tabs)/personal-data.tsx
@@ -70,7 +70,12 @@ export default function PersonalDataScreen() {
 
           <View style={styles.row}>
             <Text style={styles.label}>כתובת מגורים</Text>
-            <Text style={styles.value}>{profile?.address}, {profile?.city}</Text>
+            <Text style={styles.value}>{profile?.address}</Text>
+          </View>
+
+          <View style={styles.row}>
+            <Text style={styles.label}>עיר</Text>
+            <Text style={styles.value}>{profile?.city}</Text>
           </View>
 
           <View style={[styles.row, styles.rowLast]}>

--- a/apps/mobile/src/app/(tabs)/personal-data.tsx
+++ b/apps/mobile/src/app/(tabs)/personal-data.tsx
@@ -100,7 +100,7 @@ export default function PersonalDataScreen() {
         </View>
 
         {/* Notification Settings */}
-        <View style={[styles.section, { display: 'none' }]}>
+        <View style={styles.section}>
           <Text style={styles.sectionTitle}>הגדרת התראות</Text>
 
           <View style={styles.switchRow}>
@@ -173,10 +173,10 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#FF8C00',
     marginBottom: 10,
-    textAlign: 'right',
+    textAlign: 'auto',
   },
   row: {
-    flexDirection: 'row-reverse',
+    flexDirection: 'row',
     justifyContent: 'space-between',
     paddingVertical: 10,
     borderBottomWidth: 1,
@@ -191,8 +191,8 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     marginBottom: 10,
   },
-  cardName: { fontWeight: 'bold', textAlign: 'right' },
-  cardDetail: { textAlign: 'right', color: '#666' },
+  cardName: { fontWeight: 'bold', textAlign: 'auto' },
+  cardDetail: { textAlign: 'auto', color: '#666' },
   updateButton: {
     backgroundColor: '#FF8C00',
     padding: 15,
@@ -204,12 +204,12 @@ const styles = StyleSheet.create({
   logoutButton: { marginTop: 16, alignItems: 'center' },
   logoutText: { color: 'red', fontSize: 16 },
   switchRow: {
-    flexDirection: 'row-reverse',
+    flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 20,
   },
   switchTextContainer: { flex: 1, paddingRight: 10 },
-  switchTitle: { fontWeight: 'bold', textAlign: 'right' },
-  switchSub: { fontSize: 12, color: '#666', textAlign: 'right' },
+  switchTitle: { fontWeight: 'bold', textAlign: 'auto' },
+  switchSub: { fontSize: 12, color: '#666', textAlign: 'auto' },
 });

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { I18nManager, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack, router } from 'expo-router';
 import { registerQueryClient } from '../api/session';
+
+// The app is Hebrew-only, so force RTL layout regardless of the device's
+// system locale (some users keep their OS in English but use Hebrew apps).
+if (!I18nManager.isRTL) {
+  I18nManager.allowRTL(true);
+  I18nManager.forceRTL(true);
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/mobile/src/app/login.tsx
+++ b/apps/mobile/src/app/login.tsx
@@ -190,7 +190,13 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingBottom: 24,
   },
-  logo: { width: 150, height: 115, alignSelf: 'center', marginTop: 40 },
+  logo: {
+    width: '40%',
+    maxWidth: 150,
+    aspectRatio: 150 / 115,
+    alignSelf: 'center',
+    marginTop: 40,
+  },
   welcome: {
     fontSize: 32,
     fontWeight: 'bold',
@@ -242,7 +248,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: 'center',
     marginTop: 12,
-    marginHorizontal: 80,
+    marginHorizontal: '20%',
   },
   donationButtonText: {
     color: '#fff',

--- a/apps/mobile/src/app/login.tsx
+++ b/apps/mobile/src/app/login.tsx
@@ -210,7 +210,7 @@ const styles = StyleSheet.create({
   },
   inputContainer: { marginHorizontal: 20, marginBottom: 15 },
   label: {
-    textAlign: 'right' as const,
+    textAlign: 'auto' as const,
     fontSize: 14,
     fontWeight: 'bold',
     marginBottom: 6,
@@ -264,7 +264,7 @@ const styles = StyleSheet.create({
   fieldErrorText: {
     color: 'red',
     fontSize: 12,
-    textAlign: 'right' as const,
+    textAlign: 'auto' as const,
     marginTop: 4,
   },
 });

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -161,6 +161,7 @@ export default function VerifySmsScreen() {
             maxLength={6}
             caretHidden
             style={styles.hiddenCodeInput}
+            textAlign="left"
           />
           {digits.map((digit, i) => (
             <View
@@ -213,6 +214,7 @@ const styles = StyleSheet.create({
   },
   digitsContainer: {
     flexDirection: 'row',
+    direction: 'ltr',
     justifyContent: 'center',
     gap: 10,
     marginHorizontal: 20,

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -214,13 +214,13 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 32,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'auto',
     marginRight: 20,
     marginTop: 40,
   },
   subText: {
     fontSize: 18,
-    textAlign: 'right',
+    textAlign: 'auto',
     marginRight: 20,
     marginBottom: 20,
   },

--- a/apps/mobile/src/app/verify-sms.tsx
+++ b/apps/mobile/src/app/verify-sms.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Pressable,
   StyleSheet,
+  useWindowDimensions,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import type { FirebaseAuthTypes } from '@react-native-firebase/auth';
@@ -63,6 +64,13 @@ export default function VerifySmsScreen() {
   const [verifying, setVerifying] = useState(false);
   const { mutateAsync: createSession } = useCreateSession();
   const e164Phone = phoneNumber ? toE164(phoneNumber) : '';
+
+  // Shrink the OTP digit boxes to fit narrow screens instead of overflowing.
+  const { width: screenWidth } = useWindowDimensions();
+  const availableWidth =
+    screenWidth - styles.digitsContainer.marginHorizontal * 2 - styles.digitsContainer.gap * 5;
+  const digitBoxWidth = Math.min(44, availableWidth / 6);
+  const digitBoxHeight = digitBoxWidth * (52 / 44);
 
   const sendSms = useCallback(async () => {
     if (!phoneNumber || !e164Phone) return;
@@ -166,7 +174,11 @@ export default function VerifySmsScreen() {
           {digits.map((digit, i) => (
             <View
               key={i}
-              style={[styles.digitBox, digit ? styles.digitInputFilled : null]}
+              style={[
+                styles.digitBox,
+                { width: digitBoxWidth, height: digitBoxHeight },
+                digit ? styles.digitInputFilled : null,
+              ]}
             >
               <Text style={styles.digitText}>{digit}</Text>
             </View>
@@ -228,8 +240,6 @@ const styles = StyleSheet.create({
     color: 'transparent',
   },
   digitBox: {
-    width: 44,
-    height: 52,
     borderBottomWidth: 2,
     borderBottomColor: '#ccc',
     justifyContent: 'center',

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -42,22 +42,22 @@ export const ActivityItem = ({
         <View style={styles.metaRow}>
           {duration && (
             <View style={[styles.metaItem, styles.durationItem]}>
-              <Text style={styles.metaText}>{duration}</Text>
               <Ionicons name="time-outline" size={13} color="#888" />
+              <Text style={styles.metaText}>{duration}</Text>
             </View>
           )}
           {date && (
             <View style={styles.metaItem}>
-              <Text style={styles.metaText}>{date}</Text>
               <Ionicons name="calendar-outline" size={13} color="#888" />
+              <Text style={styles.metaText}>{date}</Text>
             </View>
           )}
         </View>
       )}
 
       <View style={[styles.metaItem, styles.locationItem]}>
-        <Text style={styles.metaText}>{location}</Text>
         <Ionicons name="location-outline" size={13} color="#888" />
+        <Text style={styles.metaText}>{location}</Text>
       </View>
 
       {host && <Text style={styles.host}>{host}</Text>}

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   metaItem: {
-    flexDirection: 'row',
+    flexDirection: 'row-reverse',
     alignItems: 'center',
     gap: 4,
   },

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'auto',
     color: '#333',
     flex: 1,
     paddingRight: 8,
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   metaItem: {
-    flexDirection: 'row-reverse',
+    flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
   },
@@ -119,7 +119,7 @@ const styles = StyleSheet.create({
     marginLeft: 20,
   },
   locationItem: {
-    alignSelf: 'flex-end',
+    alignSelf: 'flex-start',
   },
   metaText: {
     fontSize: 13,
@@ -128,10 +128,10 @@ const styles = StyleSheet.create({
   host: {
     fontSize: 13,
     color: '#888',
-    textAlign: 'right',
+    textAlign: 'auto',
   },
   detailsBtn: {
-    alignSelf: 'flex-end',
+    alignSelf: 'flex-start',
   },
   detailsLink: {
     color: '#FF8C00',

--- a/apps/mobile/src/components/ActivityItem.tsx
+++ b/apps/mobile/src/components/ActivityItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Status } from './Status';
 
@@ -11,6 +11,7 @@ interface ActivityItemProps {
   time?: string;
   location: string;
   status: string;
+  imageUrl?: string;
   onPressDetails?: () => void;
   children?: React.ReactNode;
 }
@@ -22,49 +23,48 @@ export const ActivityItem = ({
   duration,
   location,
   status,
+  imageUrl,
   onPressDetails,
   children,
 }: ActivityItemProps) => (
   <View style={styles.container}>
-    <View style={styles.cardRow}>
-      {/* Details column on the left */}
-      <View style={styles.info}>
-        <Text style={styles.title}>{title}</Text>
+    {imageUrl && (
+      <Image source={{ uri: imageUrl }} style={styles.photo} resizeMode="cover" />
+    )}
 
-        {(date || duration) && (
-          <View style={styles.metaRow}>
-            {duration && (
-              <View style={[styles.metaItem, styles.durationItem]}>
-                <Text style={styles.metaText}>{duration}</Text>
-                <Ionicons name="time-outline" size={13} color="#888" />
-              </View>
-            )}
-            {date && (
-              <View style={styles.metaItem}>
-                <Text style={styles.metaText}>{date}</Text>
-                <Ionicons name="calendar-outline" size={13} color="#888" />
-              </View>
-            )}
-          </View>
-        )}
-
-        <View style={[styles.metaItem, styles.locationItem]}>
-          <Text style={styles.metaText}>{location}</Text>
-          <Ionicons name="location-outline" size={13} color="#888" />
-        </View>
-
-        {host && <Text style={styles.host}>{host}</Text>}
-
-        <TouchableOpacity onPress={onPressDetails} style={styles.detailsBtn}>
-          <Text style={styles.detailsLink}>לפרטים נוספים</Text>
-        </TouchableOpacity>
-      </View>
-
-      {/* Right column: status badge + photo */}
-      <View style={styles.rightCol}>
+    <View style={styles.info}>
+      <View style={styles.titleRow}>
         <Status label={status} />
-        <View style={styles.photo} />
+        <Text style={styles.title}>{title}</Text>
       </View>
+
+      {(date || duration) && (
+        <View style={styles.metaRow}>
+          {duration && (
+            <View style={[styles.metaItem, styles.durationItem]}>
+              <Text style={styles.metaText}>{duration}</Text>
+              <Ionicons name="time-outline" size={13} color="#888" />
+            </View>
+          )}
+          {date && (
+            <View style={styles.metaItem}>
+              <Text style={styles.metaText}>{date}</Text>
+              <Ionicons name="calendar-outline" size={13} color="#888" />
+            </View>
+          )}
+        </View>
+      )}
+
+      <View style={[styles.metaItem, styles.locationItem]}>
+        <Text style={styles.metaText}>{location}</Text>
+        <Ionicons name="location-outline" size={13} color="#888" />
+      </View>
+
+      {host && <Text style={styles.host}>{host}</Text>}
+
+      <TouchableOpacity onPress={onPressDetails} style={styles.detailsBtn}>
+        <Text style={styles.detailsLink}>לפרטים נוספים</Text>
+      </TouchableOpacity>
     </View>
 
     {children && <View style={styles.actions}>{children}</View>}
@@ -83,30 +83,28 @@ const styles = StyleSheet.create({
     shadowRadius: 3,
     elevation: 2,
   },
-  cardRow: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  info: {
-    flex: 1,
-    gap: 6,
-  },
-  rightCol: {
-    alignItems: 'flex-start',
-    gap: 6,
-    flexShrink: 0,
-  },
   photo: {
-    width: 80,
-    height: 80,
+    width: '100%',
+    aspectRatio: 16 / 9,
     borderRadius: 8,
     backgroundColor: '#ddd',
+    marginBottom: 12,
+  },
+  info: {
+    gap: 6,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   title: {
     fontSize: 16,
     fontWeight: 'bold',
     textAlign: 'right',
     color: '#333',
+    flex: 1,
+    paddingRight: 8,
   },
   metaRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/CampaignDetailsModal.tsx
+++ b/apps/mobile/src/components/CampaignDetailsModal.tsx
@@ -43,12 +43,12 @@ export function CampaignDetailsModal({ visible, campaign, onClose }: CampaignDet
 const styles = StyleSheet.create({
   overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   content: { backgroundColor: '#fff', borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 25, maxHeight: '80%' },
-  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'right', marginBottom: 4, color: '#333' },
-  host: { fontSize: 14, textAlign: 'right', color: '#888', marginBottom: 15 },
-  detailText: { fontSize: 16, textAlign: 'right', marginBottom: 8, color: '#555' },
+  title: { fontSize: 22, fontWeight: 'bold', textAlign: 'auto', marginBottom: 4, color: '#333' },
+  host: { fontSize: 14, textAlign: 'auto', color: '#888', marginBottom: 15 },
+  detailText: { fontSize: 16, textAlign: 'auto', marginBottom: 8, color: '#555' },
   descriptionContainer: { marginTop: 20, borderTopWidth: 1, borderTopColor: '#eee', paddingTop: 15 },
-  descriptionTitle: { fontSize: 18, fontWeight: 'bold', textAlign: 'right', marginBottom: 5, color: '#333' },
-  descriptionText: { fontSize: 16, textAlign: 'right', color: '#444', lineHeight: 24 },
+  descriptionTitle: { fontSize: 18, fontWeight: 'bold', textAlign: 'auto', marginBottom: 5, color: '#333' },
+  descriptionText: { fontSize: 16, textAlign: 'auto', color: '#444', lineHeight: 24 },
   closeButton: { backgroundColor: '#FF8C00', padding: 15, borderRadius: 10, alignItems: 'center', marginTop: 25 },
   closeButtonText: { color: '#fff', fontSize: 16, fontWeight: 'bold' }
 });

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -304,7 +304,7 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
 const styles = StyleSheet.create({
   memberStatusList: { gap: 4, marginBottom: 12 },
   memberStatusRow: { flexDirection: 'row', alignItems: 'center', gap: 2 },
-  memberName: { flex: 1, fontSize: 14, color: '#333', textAlign: 'right' },
+  memberName: { flex: 1, fontSize: 14, color: '#333', textAlign: 'auto' },
   actionContainer: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'stretch', gap: 8, marginTop: 4 },
   registerButton: {
     flex: 1,
@@ -336,7 +336,7 @@ const styles = StyleSheet.create({
   },
   disabledButton: { opacity: 0.6 },
   unregisterButtonText: { color: '#fff', fontWeight: 'bold', textAlign: 'center' },
-  errorContainer: { alignItems: 'flex-end', gap: 4 },
+  errorContainer: { alignItems: 'flex-start', gap: 4 },
   errorText: { color: '#ff4444', fontSize: 13 },
   retryText: { color: '#FF8C00', fontSize: 13, fontWeight: 'bold' },
   // Contact selection bottom sheet
@@ -351,7 +351,7 @@ const styles = StyleSheet.create({
   selectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'auto',
     color: '#ff4444',
     marginBottom: 16,
   },
@@ -374,7 +374,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#ff4444',
     borderColor: '#ff4444',
   },
-  contactName: { fontSize: 16, textAlign: 'right', flex: 1, paddingLeft: 12 },
+  contactName: { fontSize: 16, textAlign: 'auto', flex: 1, paddingLeft: 12 },
   checkmark: { color: '#fff', fontSize: 14, fontWeight: 'bold', textAlign: 'center' },
   selectionButtons: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/FutureCampaignItem.tsx
+++ b/apps/mobile/src/components/FutureCampaignItem.tsx
@@ -195,6 +195,7 @@ export function FutureCampaignItem({ campaign, onShowModal, onPressDetails }: {
         date={`${campaign.startDate} | ${campaign.durationInHours} שעות`}
         location={`${campaign.locationAddress}, ${campaign.locationCity}`}
         status={members.length >= 1 ? undefined : statusText}
+        imageUrl={campaign.imageUrl}
         onPressDetails={onPressDetails}
       >
         {members.length >= 1 && (

--- a/apps/mobile/src/components/MyActivityItem.tsx
+++ b/apps/mobile/src/components/MyActivityItem.tsx
@@ -95,7 +95,7 @@ const styles = StyleSheet.create({
     paddingRight: 8,
   },
   metaItem: {
-    flexDirection: 'row',
+    flexDirection: 'row-reverse',
     alignItems: 'center',
     gap: 4,
     alignSelf: 'flex-end',

--- a/apps/mobile/src/components/MyActivityItem.tsx
+++ b/apps/mobile/src/components/MyActivityItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Status } from './Status';
 
@@ -8,6 +8,7 @@ interface MyActivityItemProps {
   date: string;
   location: string;
   status?: string;
+  imageUrl?: string;
   onPressDetails?: () => void;
   children?: React.ReactNode;
 }
@@ -17,37 +18,35 @@ export const MyActivityItem = ({
   date,
   location,
   status,
+  imageUrl,
   onPressDetails,
   children,
 }: MyActivityItemProps) => (
   <View style={styles.container}>
-    <View style={styles.cardRow}>
-      {/* Details column on the left */}
-      <View style={styles.info}>
-        {/* Status on left, name on right */}
-        <View style={styles.nameRow}>
-          {status ? <Status label={status} /> : null}
-          <Text style={styles.title}>{title}</Text>
-        </View>
+    {imageUrl && (
+      <Image source={{ uri: imageUrl }} style={styles.photo} resizeMode="cover" />
+    )}
 
-        {/* Date+time and location aligned to the right (photo side) */}
-        <View style={styles.metaItem}>
-          <Text style={styles.metaText}>{date}</Text>
-          <Ionicons name="time-outline" size={13} color="#888" />
-        </View>
-
-        <View style={styles.metaItem}>
-          <Text style={styles.metaText}>{location}</Text>
-          <Ionicons name="location-outline" size={13} color="#888" />
-        </View>
-
-        <TouchableOpacity onPress={onPressDetails} style={styles.detailsBtn}>
-          <Text style={styles.detailsLink}>לפרטים נוספים</Text>
-        </TouchableOpacity>
+    <View style={styles.info}>
+      {/* Status on left, name on right */}
+      <View style={styles.nameRow}>
+        {status ? <Status label={status} /> : null}
+        <Text style={styles.title}>{title}</Text>
       </View>
 
-      {/* Photo on the right */}
-      <View style={styles.photo} />
+      <View style={styles.metaItem}>
+        <Text style={styles.metaText}>{date}</Text>
+        <Ionicons name="time-outline" size={13} color="#888" />
+      </View>
+
+      <View style={styles.metaItem}>
+        <Text style={styles.metaText}>{location}</Text>
+        <Ionicons name="location-outline" size={13} color="#888" />
+      </View>
+
+      <TouchableOpacity onPress={onPressDetails} style={styles.detailsBtn}>
+        <Text style={styles.detailsLink}>לפרטים נוספים</Text>
+      </TouchableOpacity>
     </View>
 
     {children && <View style={styles.actions}>{children}</View>}
@@ -66,20 +65,15 @@ const styles = StyleSheet.create({
     shadowRadius: 3,
     elevation: 2,
   },
-  cardRow: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  info: {
-    flex: 1,
-    gap: 6,
-  },
   photo: {
-    width: 80,
-    height: 80,
+    width: '100%',
+    aspectRatio: 16 / 9,
     borderRadius: 8,
     backgroundColor: '#ddd',
-    flexShrink: 0,
+    marginBottom: 12,
+  },
+  info: {
+    gap: 6,
   },
   nameRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/MyActivityItem.tsx
+++ b/apps/mobile/src/components/MyActivityItem.tsx
@@ -84,22 +84,22 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     color: '#333',
-    textAlign: 'right',
+    textAlign: 'auto',
     flex: 1,
     paddingRight: 8,
   },
   metaItem: {
-    flexDirection: 'row-reverse',
+    flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    alignSelf: 'flex-end',
+    alignSelf: 'flex-start',
   },
   metaText: {
     fontSize: 13,
     color: '#666',
   },
   detailsBtn: {
-    alignSelf: 'flex-end',
+    alignSelf: 'flex-start',
     marginTop: 4,
   },
   detailsLink: {

--- a/apps/mobile/src/components/MyActivityItem.tsx
+++ b/apps/mobile/src/components/MyActivityItem.tsx
@@ -35,13 +35,13 @@ export const MyActivityItem = ({
       </View>
 
       <View style={styles.metaItem}>
-        <Text style={styles.metaText}>{date}</Text>
         <Ionicons name="time-outline" size={13} color="#888" />
+        <Text style={styles.metaText}>{date}</Text>
       </View>
 
       <View style={styles.metaItem}>
-        <Text style={styles.metaText}>{location}</Text>
         <Ionicons name="location-outline" size={13} color="#888" />
+        <Text style={styles.metaText}>{location}</Text>
       </View>
 
       <TouchableOpacity onPress={onPressDetails} style={styles.detailsBtn}>


### PR DESCRIPTION
**OTP entry (verify-sms.tsx)**
Digit boxes now fill left→right as type
Digit boxes resize to fit narrow screens instead of overflowing

**Personal data screen (personal-data.tsx)**
Split the combined address row into separate כתובת מגורים (address) and עיר (city) fields.
Restored the notification-preferences toggles

**Hebrew RTL layout (app-wide)**
Reordered text order in login screen, activities screen, personal data screen.
Reordered icon+text pairs (date/duration/location rows) so the icon now reads before the text, matching natural Hebrew reading order.

**Responsive sizing**
Replaced fixed pixel widths (OTP boxes, card images, login logo/donation button) with %-based widths, aspectRatio, and useWindowDimensions so layouts don't clip or cram on small Android devices.

**Campaign cards (ActivityItem, MyActivityItem)**
Redesigned cards so the campaign image sits full-width above the text (16:9, with spacing) instead of a small side-column placeholder.
Wired imageUrl from GetFutureCampaignDto/GetPastCampaignDto through activities.tsx, FutureCampaignItem.tsx, and past.tsx; the image only renders when a URL is present, so no grey placeholder shows otherwise.